### PR TITLE
(SF Library) Rename ACF.VelScale to ACF.Scale

### DIFF
--- a/lua/starfall/libs_sv/acffunctions.lua
+++ b/lua/starfall/libs_sv/acffunctions.lua
@@ -1971,7 +1971,7 @@ function ents_methods:acfMuzzleVel ()
 
 	if not ( isAmmo( this ) or isGun( this ) ) then return 0 end
 	if restrictInfo( this ) then return 0 end
-	return math.Round( ( this.BulletData[ "MuzzleVel" ] or 0 ) * ACF.VelScale, 3 )
+	return math.Round( ( this.BulletData[ "MuzzleVel" ] or 0 ) * ACF.Scale, 3 )
 end
 
 --- Returns the mass of the projectile in a crate or gun


### PR DESCRIPTION
Fixes:
`Callback errored with: starfall/libs_sv/acffunctions.lua:1974: attempt to perform arithmetic on field 'VelScale' (a nil value)`