### PR TITLE
[Starfall Library] Change this.AmmoLink to this.Crates

### DIFF
--- a/lua/starfall/libs_sv/acffunctions.lua
+++ b/lua/starfall/libs_sv/acffunctions.lua
@@ -1832,7 +1832,7 @@ function ents_methods:acfAmmoCount ()
 	if not isGun( this ) then return 0 end
 	if restrictInfo( this ) then return 0 end
 	local Ammo = 0
-	for Key, AmmoEnt in pairs( this.AmmoLink ) do
+	for AmmoEnt in pairs( this.Crates ) do
 		if AmmoEnt and AmmoEnt:IsValid() and AmmoEnt[ "Load" ] then
 			Ammo = Ammo + ( AmmoEnt.Ammo or 0 )
 		end
@@ -1851,7 +1851,7 @@ function ents_methods:acfTotalAmmoCount ()
 	if not isGun( this ) then return 0 end
 	if restrictInfo( this ) then return 0 end
 	local Ammo = 0
-	for Key, AmmoEnt in pairs( this.AmmoLink ) do
+	for AmmoEnt in pairs( this.Crates ) do
 		if AmmoEnt and AmmoEnt:IsValid() then
 			Ammo = Ammo + ( AmmoEnt.Ammo or 0 )
 		end


### PR DESCRIPTION
This got fixed back in December but must have been changed back when some other SF lib changes got merged.