### PR TITLE
Fixed edge-case with non edge-case means

### DIFF
--- a/lua/entities/acf_ammo/init.lua
+++ b/lua/entities/acf_ammo/init.lua
@@ -211,8 +211,10 @@ local function CalcAmmo(BoxSize,GunData,BulletData,AddSpacing,AddArmor)
 			ExtraData.LocalAng = Angle(90,90,0)
 		end
 
-		local ModifiedRoundSize = ConvCaliber + Spacing
 		local ModifiedRoundLength = ConvLength + Spacing
+		local ModifiedRoundSize = ConvCaliber + Spacing
+		-- Doesn't use round spacing for length wise if its just 1, because edge cases are fun
+		if (math.floor(D[ShortestFit] / ConvLength) == 1) then ModifiedRoundLength = ConvLength end
 		-- That basic bitch math
 		ExtraData.RoundSize = Vector(ConvLength,ConvCaliber,ConvCaliber)
 		local RoundsX = math.floor(D[ShortestFit] / ModifiedRoundLength)
@@ -272,6 +274,8 @@ local function CalcAmmo(BoxSize,GunData,BulletData,AddSpacing,AddArmor)
 				end
 
 				local ModifiedRoundLength = ConvLength + Spacing
+				-- Doesn't use round spacing for length wise if its just 1, because edge cases are fun
+				if (math.floor(D[ShortestFit] / ConvLength) == 1) then ModifiedRoundLength = ConvLength end
 				ExtraData.RoundSize = Vector(ConvLength,RoundWidth,RoundHeight)
 				local RoundsX = math.floor(D[ShortestFit] / ModifiedRoundLength)
 				local RoundsY = math.floor(D2[ShortestWidth] / (RoundWidth + Spacing))


### PR DESCRIPTION
Mildly changed how final box capacity is calculated, basically ran into the perfect edgecase which brought this to light:
- Previously, the system further up checked for the shortest possible fitting distance, but notably WITHOUT round spacing, and when it came time to count rounds, it did so WITH round spacing, and as such if it perfectly fit between with and without spacing it wouldn't fit any at all
What I did to fix this was check if it can fit JUST 1 round in the pointing direction, and if could fit only 1 that way, then get rid of the spacing, otherwise it will use spacing for multiple rounds