### PR TITLE
Quick fix for clientside hitbox

### DIFF
--- a/lua/acf/shared/hitboxes.lua
+++ b/lua/acf/shared/hitboxes.lua
@@ -187,9 +187,11 @@ end)
 if CLIENT then
 	net.Receive("ACF_SeatHitboxes",function()
 		local Seat = net.ReadEntity()
+		if not IsValid(Seat) then return end -- out of PVS?
 		local Type = net.ReadString()
 		HitBox = table.Copy(HitboxStorage[Type].HitBoxes)
 		local ply = Seat:GetDriver()
+		if not IsValid(ply) then return end -- eeeee someone got out
 
 		for k,v in pairs(HitBox) do
 			HitBox[k].Pos = Seat:WorldToLocal(ply:LocalToWorld(v.Pos))


### PR DESCRIPTION
This fixes an error where clients were getting hitbox data for seats that weren't in their PVS, so it was a null entity and therefore would not be able to give a driver; Until this gets mildly reworked to be queued (low priority, this part doesn't affect much), players will have to sit down in the seat again (3 seconds) in order to rebroadcast the hitbox
Fixes #96 