### PR TITLE
Clientside debris

### DIFF
--- a/lua/acf/client/cl_damage.lua
+++ b/lua/acf/client/cl_damage.lua
@@ -1,3 +1,8 @@
+local RandFloat = math.Rand
+local RandInt = math.random
+local Clamp = math.Clamp
+local MathMax = math.max
+
 local Damaged = {
 	CreateMaterial("ACF_Damaged1", "VertexLitGeneric", {
 		["$basetexture"] = "damaged/damaged1"
@@ -68,3 +73,48 @@ net.Receive("ACF_RenderDamage", function()
 	end
 end)
 
+-- Debris & Burning Debris Effects --
+
+local function FadeAway( Ent ) -- local function Entity:FadeAway() is incorrect syntax????????? Am I referencing a hook somehow?
+	if not IsValid(Ent) then return end
+	Ent:SetRenderMode(RENDERMODE_TRANSCOLOR)
+	Ent:SetRenderFX(kRenderFxFadeFast) -- interestingly, not synced to CurTime().
+	timer.Simple(1, function() Ent:Remove() end)
+end
+
+net.Receive("ACF_Debris", function()
+
+	local HitVec = net.ReadVector()
+	local Power = net.ReadFloat()
+	local Mass = net.ReadFloat()
+	local Mdl = net.ReadString()
+	local Mat = net.ReadString()
+	local Col = net.ReadColor()
+	local Pos = net.ReadVector()
+	local Ang = net.ReadAngle()
+
+	local Debris = ents.CreateClientProp(Mdl)
+		Debris:SetPos(Pos)
+		Debris:SetAngles(Ang)
+		Debris:SetColor(Col)
+		if Mat then Debris:SetMaterial(Mat) end
+	Debris:Spawn()
+	local DebrisLifetime = RandFloat(30,60)
+	timer.Simple(DebrisLifetime, function() FadeAway(Debris) end)
+
+	if IsValid(Debris) then
+		local Phys = Debris:GetPhysicsObject()
+		if IsValid(Phys) then
+			Phys:SetMass(Mass*0.1)
+			Phys:ApplyForceOffset(HitVec:GetNormalized() * Power * 70, Debris:GetPos() + VectorRand() * 20)
+		end
+	end
+	-- Trust me when I say I wanted to do so much more than this. Gibs on fire. But very little can be achieved with clientside props...
+	-- some day.
+
+	local BreakEffect = EffectData()
+		BreakEffect:SetOrigin(Pos) -- TODO: Change this to the hit vector, but we need to redefine HitVec as HitNorm
+		BreakEffect:SetScale(20)
+	util.Effect("cball_explode", BreakEffect)
+
+end)

--- a/lua/entities/acf_debris/cl_init.lua
+++ b/lua/entities/acf_debris/cl_init.lua
@@ -1,0 +1,10 @@
+include("shared.lua")
+
+function ENT:Initialize()
+	self:CreateParticleEffect("burning_gib_01")
+	self:SetNoDraw(true)
+end
+
+function ENT:OnRemove()
+	self:StopAndDestroyParticles()
+end

--- a/lua/entities/acf_debris/init.lua
+++ b/lua/entities/acf_debris/init.lua
@@ -3,19 +3,7 @@ AddCSLuaFile("shared.lua")
 include("shared.lua")
 
 function ENT:Initialize()
+	self:SetModel("models/hunter/plates/plate.mdl")
 	self:PhysicsInit(SOLID_VPHYSICS)
-	self:SetMoveType(MOVETYPE_VPHYSICS)
-	self:SetCollisionGroup(COLLISION_GROUP_WORLD)
-
-	local PhysObj = self:GetPhysicsObject()
-
-	if IsValid(PhysObj) then
-		PhysObj:Wake()
-	end
-
-	timer.Simple(30, function()
-		if IsValid(self) then
-			self:Remove()
-		end
-	end)
+	self:SetCollisionGroup(COLLISION_GROUP_DEBRIS)
 end

--- a/lua/entities/acf_debris/shared.lua
+++ b/lua/entities/acf_debris/shared.lua
@@ -1,3 +1,4 @@
 DEFINE_BASECLASS("base_anim")
 
-ENT.PrintName = "Debris"
+ENT.PrintName = "Fireball"
+ENT.RenderGroup = RENDERGROUP_OTHER


### PR DESCRIPTION
The changes made adds a net message for every new piece of clientside debris, describing its orientation in the world and other properties when it was killed. This should hopefully lighten the load on the server and may prevent debris crashes.

There's still a lot more that can be done with this, such as adding a dedicated entity to attach particle effects to on the clientside, but for now, it's working stable.