### PR TITLE
Give RACs APDS and APCR.

### DIFF
--- a/lua/acf/shared/rounds/apcr.lua
+++ b/lua/acf/shared/rounds/apcr.lua
@@ -1,4 +1,4 @@
-ACF.AmmoBlacklist.APCR = { "MO", "SL", "HW", "MG", "SB", "RAC", "GL", "AAM", "ARTY", "ASM", "BOMB", "GBU", "POD", "SAM", "UAR", "FFAR", "FGL" }
+ACF.AmmoBlacklist.APCR = { "MO", "SL", "HW", "MG", "SB", "GL", "AAM", "ARTY", "ASM", "BOMB", "GBU", "POD", "SAM", "UAR", "FFAR", "FGL" }
 
 local Round = {}
 

--- a/lua/acf/shared/rounds/apds.lua
+++ b/lua/acf/shared/rounds/apds.lua
@@ -1,4 +1,4 @@
-ACF.AmmoBlacklist.APDS = { "MO", "SL", "HW", "SC", "MG", "SB", "RAC", "GL", "HMG", "AAM", "ARTY", "ASM", "BOMB", "GBU", "POD", "SAM", "UAR", "FFAR", "FGL" }
+ACF.AmmoBlacklist.APDS = { "MO", "SL", "HW", "SC", "MG", "SB", "GL", "HMG", "AAM", "ARTY", "ASM", "BOMB", "GBU", "POD", "SAM", "UAR", "FFAR", "FGL" }
 
 local Round = {}
 


### PR DESCRIPTION
Currently RACs are the only automatic weapons lacking these ammo types. As they are the heaviest automatic weapon type for a given caliber there is no reason to restrict them from ammo types that don't trigger any known bugs at a higher rate than AP.