### PR TITLE
HMG, Smoke Launcher rebalance

### DIFF
--- a/lua/acf/shared/guns/heavymachinegun.lua
+++ b/lua/acf/shared/guns/heavymachinegun.lua
@@ -1,6 +1,6 @@
 --define the class
 ACF_defineGunClass("HMG", {
-	spread = 0.24,
+	spread = 1.2,
 	name = "Heavy Machinegun",
 	desc = "Designed as autocannons for aircraft, HMGs are rapid firing, lightweight, and compact but sacrifice accuracy, magazine size, and reload times.  They excel at strafing and dogfighting.\nBecause of their long reload times and high rate of fire, it is best to aim BEFORE pushing the almighty fire switch.",
 	muzzleflash = "mg_muzzleflash_noscale",

--- a/lua/acf/shared/guns/smokelauncher.lua
+++ b/lua/acf/shared/guns/smokelauncher.lua
@@ -4,7 +4,7 @@ ACF_defineGunClass("SL", {
 	name = "Smoke Launcher",
 	desc = "Smoke launcher to block an attacker's line of sight.",
 	muzzleflash = "gl_muzzleflash_noscale",
-	rofmod = 45,
+	rofmod = 22.5,
 	sound = "acf_base/weapons/smoke_launch.mp3",
 	soundDistance = "Mortar.Fire",
 	soundNormal = " "


### PR DESCRIPTION
The smoke launcher's reload has been buffed since most people just used the heavier, but far faster firing and versatile mortars anyways.

The heavy machinegun's spread has been increased to discourage its use against ground targets, while keeping it an effective AA weapon.