### PR TITLE
Update smokelauncher.lua

### DIFF
--- a/lua/acf/shared/guns/smokelauncher.lua
+++ b/lua/acf/shared/guns/smokelauncher.lua
@@ -23,7 +23,7 @@ ACF_defineGun("40mmSL", {
 	year = 1941,
 	magsize = 1,
 	magreload = 30,
-	Cyclic = 1,
+	Cyclic = 600,
 	round = {
 		maxlength = 17.5,
 		propweight = 0.000075
@@ -42,11 +42,11 @@ ACF_defineGun("40mmCL", {
 	weight = 20,
 	rofmod = 0.015,
 	magsize = 6,
-	magreload = 40,
+	magreload = 15,
 	Cyclic = 200,
 	year = 1950,
 	round = {
-		maxlength = 12,
+		maxlength = 17.5,
 		propweight = 0.001
 	}
 })


### PR DESCRIPTION
-40mm CL rounds now have the same length as 40mm SL rounds.
-reload changes actually work this time.