### PR TITLE
Fixed missile/bomb sizing

### DIFF
--- a/lua/acf/base/sh_round_functions.lua
+++ b/lua/acf/base/sh_round_functions.lua
@@ -225,8 +225,8 @@ do -- Ammo crate capacity calculation
 
 		-- Filters for missiles, and sets up data
 		if GunData.Round.ActualWidth then
-			RoundCaliber = GunData.Round.ActualWidth
-			RoundLength = GunData.Round.ActualLength
+			RoundCaliber = GunData.Round.ActualWidth * (1 / 0.3937) -- This was made before the big measurement change throughout, where I measured shit in actual source units
+			RoundLength = GunData.Round.ActualLength * (1 / 0.3937) -- as such, this corrects all missiles to the correct size
 			ExtraData.IsRacked = true
 		elseif GunData.Class.Entity == "acf_rack" then
 			local Efficiency = 0.1576 * ACF.AmmoMod


### PR DESCRIPTION
Due to a previous measurement change, missiles that had their actual measured size put in were smaller than the actual sizes
This fix also enables further missiles to be measured simply by measuring the source unit size