### PR TITLE
Updated crate capacity code to use new missile dimensions

### DIFF
--- a/lua/acf/base/sh_round_functions.lua
+++ b/lua/acf/base/sh_round_functions.lua
@@ -225,8 +225,8 @@ do -- Ammo crate capacity calculation
 
 		-- Filters for missiles, and sets up data
 		if GunData.Round.ActualWidth then
-			RoundCaliber = GunData.Round.ActualWidth * (1 / 0.3937) -- This was made before the big measurement change throughout, where I measured shit in actual source units
-			RoundLength = GunData.Round.ActualLength * (1 / 0.3937) -- as such, this corrects all missiles to the correct size
+			RoundCaliber = GunData.Round.ActualWidth -- Missile size does not depend on the propellant or projectile sizes
+			RoundLength = GunData.Round.ActualLength
 			ExtraData.IsRacked = true
 		elseif GunData.Class.Entity == "acf_rack" then
 			local Efficiency = 0.1576 * ACF.AmmoMod


### PR DESCRIPTION
See: [https://github.com/TwistedTail/ACF-3-Missiles/pull/28](url) (and only merge if that is merged)

Updates the code to use the missile size in cm like described in the PR above.