### PR TITLE
Fix CurTime init

### DIFF
--- a/lua/acf/base/acf_globals.lua
+++ b/lua/acf/base/acf_globals.lua
@@ -5,6 +5,7 @@ do -- ACF global vars
 	ACF.Repositories       = ACF.Repositories or {}
 	ACF.ClientData         = ACF.ClientData or {}
 	ACF.ServerData         = ACF.ServerData or {}
+	ACF.CurTime            = CurTime()
 
 	-- General Settings
 	ACF.Gamemode           = 2 -- Gamemode of the server. 1 = Sandbox, 2 = Classic, 3 = Competitive
@@ -62,7 +63,7 @@ do -- ACF global vars
 	ACF.AmmoArmor          = 5 -- How many millimeters of armor ammo crates have
 	ACF.AmmoPadding        = 2 -- Millimeters of wasted space between rounds
 	ACF.AmmoMod            = 1.05 -- DEPRECATED. Ammo modifier. 1 is 1x the amount of ammo. 0.6 default
-	ACF.AmmoCaseScale      = 1.4 -- How much larger the diameter of the case is versus the projectile (necked cartridges, M829 is 1.4, .50 BMG is 1.6) 
+	ACF.AmmoCaseScale      = 1.4 -- How much larger the diameter of the case is versus the projectile (necked cartridges, M829 is 1.4, .50 BMG is 1.6)
 	ACF.PBase              = 875 --1KG of propellant produces this much KE at the muzzle, in kj
 	ACF.PScale             = 1 --Gun Propellant power expotential
 	ACF.MVScale            = 0.5 --Propellant to MV convertion expotential
@@ -110,7 +111,7 @@ do -- ACF global vars
 	ACF.LiIonED            = 0.458 -- li-ion energy density: kw hours / liter
 	ACF.CuIToLiter         = 0.0163871 -- cubic inches to liters
 	ACF.RefillDistance     = 300 --Distance in which ammo crate starts refilling.
-	ACF.RefillSpeed        = 700 -- (ACF.RefillSpeed / RoundMass) / Distance 
+	ACF.RefillSpeed        = 700 -- (ACF.RefillSpeed / RoundMass) / Distance
 	ACF.RefuelSpeed        = 20 -- Liters per second * ACF.FuelRate
 end
 


### PR DESCRIPTION
Some clients will experience this error shortly after spawning in:
```
Lua Error:

[acf-3] addons/acf-3/lua/entities/acf_gun/cl_init.lua:31: attempt to perform arithmetic on field 'CurTime' (a nil value)
  1. unknown - addons/acf-3/lua/entities/acf_gun/cl_init.lua:31
```

I believe this is because already-spawned entities run their `Think` hook before the client does. The client sets `ACF.CurTime = CurTime()` on `Think`, but if that hasn't run yet, it'll be `nil`.

This PR sets the value on the initial table setup, preventing this error.

I also took the liberty of removing a couple of trailing spaces in the same file.