### PR TITLE
Update ballistics.lua

### DIFF
--- a/lua/acf/client/ballistics.lua
+++ b/lua/acf/client/ballistics.lua
@@ -5,7 +5,7 @@ local function BulletFlight(Bullet)
 	local Drag = Bullet.SimFlight:GetNormalized() *  (Bullet.DragCoef * Bullet.SimFlight:Length() ^ 2 ) / ACF.DragDiv
 
 	Bullet.SimPosLast = Bullet.SimPos
-	Bullet.SimPos = Bullet.SimPos + (Bullet.SimFlight * ACF.Scale * DeltaTime)		--Calculates the next shell position
+	Bullet.SimPos = Bullet.SimPos + (Bullet.SimFlight * ACF.Scale * DeltaTime) + (0.5 * ACF.Scale * (Bullet.Accel - Drag) * DeltaTime * DeltaTime)		--Calculates the next shell position
 	Bullet.SimFlight = Bullet.SimFlight + (Bullet.Accel - Drag) * DeltaTime			--Calculates the next shell vector
 
 	if IsValid(Bullet.Effect) then

--- a/lua/acf/client/ballistics.lua
+++ b/lua/acf/client/ballistics.lua
@@ -6,7 +6,7 @@ local function BulletFlight(Bullet)
 
 	Bullet.SimPosLast = Bullet.SimPos
 	local Correction = 0.5 * (Bullet.Accel - Drag) * DeltaTime   --Double integrates constant acceleration for better positional accuracy
-	Bullet.SimPos = Bullet.SimPos + ACF.Scale * DeltaTime * (Bullet.SimFlight + PositionCorrection)  --Calculates the next shell position
+	Bullet.SimPos = Bullet.SimPos + ACF.Scale * DeltaTime * (Bullet.SimFlight + Correction)  --Calculates the next shell position
 	Bullet.SimFlight = Bullet.SimFlight + (Bullet.Accel - Drag) * DeltaTime			--Calculates the next shell vector
 
 	if IsValid(Bullet.Effect) then

--- a/lua/acf/client/ballistics.lua
+++ b/lua/acf/client/ballistics.lua
@@ -5,7 +5,8 @@ local function BulletFlight(Bullet)
 	local Drag = Bullet.SimFlight:GetNormalized() *  (Bullet.DragCoef * Bullet.SimFlight:Length() ^ 2 ) / ACF.DragDiv
 
 	Bullet.SimPosLast = Bullet.SimPos
-	Bullet.SimPos = Bullet.SimPos + (Bullet.SimFlight * ACF.Scale * DeltaTime) + (0.5 * ACF.Scale * (Bullet.Accel - Drag) * DeltaTime * DeltaTime)		--Calculates the next shell position
+	local Correction = 0.5 * (Bullet.Accel - Drag) * DeltaTime   --Double integrates constant acceleration for better positional accuracy
+	Bullet.SimPos = Bullet.SimPos + ACF.Scale * DeltaTime * (Bullet.SimFlight + PositionCorrection)  --Calculates the next shell position
 	Bullet.SimFlight = Bullet.SimFlight + (Bullet.Accel - Drag) * DeltaTime			--Calculates the next shell vector
 
 	if IsValid(Bullet.Effect) then

--- a/lua/acf/server/ballistics.lua
+++ b/lua/acf/server/ballistics.lua
@@ -121,7 +121,8 @@ function ACF.CalcBulletFlight(Bullet)
 	local Drag      = Bullet.Flight:GetNormalized() * (Bullet.DragCoef * Bullet.Flight:LengthSqr()) / ACF.DragDiv
 	local Accel     = Bullet.Accel or Gravity
 
-	Bullet.NextPos   = Bullet.Pos + (Bullet.Flight * ACF.Scale * DeltaTime) + (0.5 * ACF.Scale * (Accel - Drag) * DeltaTime * DeltaTime)
+	local Correction = 0.5 * (Accel - Drag) * DeltaTime
+	Bullet.NextPos   = Bullet.Pos + ACF.Scale * DeltaTime * (Bullet.Flight + Correction)
 	Bullet.Flight    = Bullet.Flight + (Accel - Drag) * DeltaTime
 	Bullet.LastThink = ACF.CurTime
 	Bullet.DeltaTime = DeltaTime

--- a/lua/acf/server/ballistics.lua
+++ b/lua/acf/server/ballistics.lua
@@ -121,7 +121,7 @@ function ACF.CalcBulletFlight(Bullet)
 	local Drag      = Bullet.Flight:GetNormalized() * (Bullet.DragCoef * Bullet.Flight:LengthSqr()) / ACF.DragDiv
 	local Accel     = Bullet.Accel or Gravity
 
-	Bullet.NextPos   = Bullet.Pos + (Bullet.Flight * ACF.Scale * DeltaTime)
+	Bullet.NextPos   = Bullet.Pos + (Bullet.Flight * ACF.Scale * DeltaTime) + (0.5 * ACF.Scale * (Accel - Drag) * DeltaTime * DeltaTime)
 	Bullet.Flight    = Bullet.Flight + (Accel - Drag) * DeltaTime
 	Bullet.LastThink = ACF.CurTime
 	Bullet.DeltaTime = DeltaTime


### PR DESCRIPTION
Bullet.NextPos now includes double integration of acceleration as well instead of just integration of velocity.

The ballistic simulation is a lot more accurate now. But because it was already very accurate it's almost impossible to see the difference, especially if one accounts for the bullet spread.

I did not test it in-game but I did some simulations and it fixes less than 5 cm of vertical drop when firing steel darts at a distance of 800 meters. I showed some plots and results on Discord.

One case, where I can see this actually making a tangible difference, is the consistency of shots between servers with different tick rates. At lower tick rates the shots should resemble their higher tick rate counterparts a lot closer with this.