### PR TITLE
HEAT penetration fix

### DIFF
--- a/lua/acf/shared/ammo_types/heat.lua
+++ b/lua/acf/shared/ammo_types/heat.lua
@@ -56,7 +56,7 @@ function Ammo:GetDisplayData(Data)
 		SlugMassUsed   = Data.SlugMass,
 		MaxPen         = self:GetPenetration(Data, Data.MuzzleVel, true),
 		TotalFragMass  = Data.CasingMass,
-		BlastRadius    = Data.HEATFillerMass ^ 0.33 * 8,
+		BlastRadius    = Data.BoomFillerMass ^ 0.33 * 8,
 		Fragments      = Fragments,
 		FragMass       = Data.CasingMass / Fragments,
 		FragVel        = (Data.HEATFillerMass * ACF.HEPower * 1000 / Data.CasingMass) ^ 0.5,
@@ -97,8 +97,8 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 	Data.SlugCaliber    = SlugCaliber
 	Data.SlugDragCoef   = SlugArea * 0.0001 / Data.SlugMass
 	Data.BoomFillerMass	= Data.FillerMass * ACF.HEATBoomConvert
-	Data.HEATFillerMass = Data.FillerMass * (1 - ACF.HEATBoomConvert)
-	Data.SlugMV			= self:CalcSlugMV(Data)
+	Data.HEATFillerMass = Data.FillerMass
+	Data.SlugMV			= self:CalcSlugMV(Data) * (Data.SlugPenMul or 1)
 	Data.CasingMass		= Data.ProjMass - Data.FillerMass - ConeVol * 0.0079
 	Data.DragCoef		= Data.ProjArea * 0.0001 / Data.ProjMass
 	Data.CartMass		= Data.PropMass + Data.ProjMass


### PR DESCRIPTION
I made a couple of mistakes when removing crush, got through due to lack of testing. This time I tested it and it works correctly.

The blast radius now correctly uses the converted HE power, and the HEAT filler isn't diminished by the converted HE. Penetration multiplier is also correctly applied now.