### PR TITLE
Changed shell filler capacity and filler slider behavior

### DIFF
--- a/lua/acf/base/acf_globals.lua
+++ b/lua/acf/base/acf_globals.lua
@@ -78,6 +78,10 @@ do -- ACF global vars
 	ACF.HEATPenLayerMul    = 0.75 --HEAT base energy multiplier
 	ACF.HEATBoomConvert    = 1 / 3 -- percentage of filler that creates HE damage at detonation
 
+	-- Material densities
+	ACF.SteelDensity       = 7.9e-3	-- kg/cm^3
+	ACF.AluminumDensity    = 2.7e-3	-- kg/cm^3
+
 	-- Debris
 	ACF.ChildDebris        = 50 -- higher is more debris props; Chance = ACF.ChildDebris / num_children; Only applies to children of acf-killed parent props
 	ACF.DebrisIgniteChance = 0.25

--- a/lua/acf/base/sh_round_functions.lua
+++ b/lua/acf/base/sh_round_functions.lua
@@ -165,8 +165,9 @@ function ACF.GetWeaponBlacklist(Whitelist)
 	return Result
 end
 
-function ACF.RoundShellCapacity(Momentum, ProjArea, Caliber, ProjLength)
-	local MinWall = 0.2 + ((Momentum / ProjArea) ^ 0.7) * 0.02 --The minimal shell wall thickness required to survive firing at the current energy level
+function ACF.RoundShellCapacity(PropMass, ProjArea, Caliber, ProjLength)
+	local PropEnergy = ACF.PropImpetus * PropMass
+	local MinWall = 0.2 + ((PropEnergy / ProjArea) ^ 0.7) * 0.035 --The minimal shell wall thickness required to survive firing at the current energy level
 	local Length = math.max(ProjLength - MinWall, 0)
 	local Radius = math.max((Caliber * 0.5) - MinWall, 0)
 	local Volume = math.pi * Radius ^ 2 * Length

--- a/lua/acf/shared/ammo_types/ap.lua
+++ b/lua/acf/shared/ammo_types/ap.lua
@@ -36,7 +36,7 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 
 	ACF.UpdateRoundSpecs(ToolData, Data, GUIData)
 
-	Data.ProjMass   = Data.ProjArea * Data.ProjLength * 0.0079 --Volume of the projectile as a cylinder * density of steel
+	Data.ProjMass   = Data.ProjArea * Data.ProjLength * ACF.SteelDensity --Volume of the projectile as a cylinder * density of steel
 	Data.MuzzleVel  = ACF.MuzzleVelocity(Data.PropMass, Data.ProjMass, Data.Efficiency)
 	Data.DragCoef   = Data.ProjArea * 0.0001 / Data.ProjMass
 	Data.CartMass   = Data.PropMass + Data.ProjMass

--- a/lua/acf/shared/ammo_types/apcr.lua
+++ b/lua/acf/shared/ammo_types/apcr.lua
@@ -21,7 +21,7 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 
 	ACF.UpdateRoundSpecs(ToolData, Data, GUIData)
 
-	Data.ProjMass  = Data.ProjArea * Data.ProjLength * 0.0079 --Volume of the projectile as a cylinder * density of steel (kg/in3)
+	Data.ProjMass  = Data.ProjArea * Data.ProjLength * ACF.SteelDensity --Volume of the projectile as a cylinder * density of steel (kg/in3)
 	Data.MuzzleVel = ACF.MuzzleVelocity(Data.PropMass, Data.ProjMass, Data.Efficiency)
 	Data.DragCoef  = Data.ProjArea * 0.0001 / Data.ProjMass
 	Data.CartMass  = Data.PropMass + Data.ProjMass

--- a/lua/acf/shared/ammo_types/apds.lua
+++ b/lua/acf/shared/ammo_types/apds.lua
@@ -21,9 +21,9 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 
 	local Cylinder  = (math.pi * (Data.Caliber * 0.5) ^ 2) * Data.ProjLength * 0.5 -- A cylinder 1/2 the length of the projectile
 	local Hole		= Data.ProjArea * Data.ProjLength * 0.5 -- Volume removed by the hole the dart passes through
-	local SabotMass = (Cylinder - Hole) * 0.0027 -- Aluminum sabot
+	local SabotMass = (Cylinder - Hole) * ACF.AluminumDensity -- Aluminum sabot
 
-	Data.ProjMass  = Data.ProjArea * Data.ProjLength * 0.0079 -- Volume of the projectile as a cylinder * density of steel
+	Data.ProjMass  = Data.ProjArea * Data.ProjLength * ACF.SteelDensity -- Volume of the projectile as a cylinder * density of steel
 	Data.MuzzleVel = ACF.MuzzleVelocity(Data.PropMass, Data.ProjMass + SabotMass, Data.Efficiency)
 	Data.DragCoef  = Data.ProjArea * 0.000125 / Data.ProjMass -- Worse drag (Manually fudged to make a meaningful difference)
 	Data.CartMass  = Data.PropMass + Data.ProjMass + SabotMass

--- a/lua/acf/shared/ammo_types/apfsds.lua
+++ b/lua/acf/shared/ammo_types/apfsds.lua
@@ -46,9 +46,9 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 
 	local Cylinder  = (math.pi * (Data.Caliber * 0.5) ^ 2) * Data.ProjLength * 0.25 -- A cylinder 1/4 the length of the projectile
 	local Hole		= Data.ProjArea * Data.ProjLength * 0.25 -- Volume removed by the hole the dart passes through
-	local SabotMass = (Cylinder - Hole) * 0.0027 -- A cylinder with a hole the size of the dart in it and im no math wizard so we're just going to take off 3/4 of the mass for the cutout since sabots are shaped like this: ][
+	local SabotMass = (Cylinder - Hole) * ACF.AluminumDensity -- A cylinder with a hole the size of the dart in it and im no math wizard so we're just going to take off 3/4 of the mass for the cutout since sabots are shaped like this: ][
 
-	Data.ProjMass  = Data.ProjArea * Data.ProjLength * 0.0079 -- Volume of the projectile as a cylinder * density of steel
+	Data.ProjMass  = Data.ProjArea * Data.ProjLength * ACF.SteelDensity -- Volume of the projectile as a cylinder * density of steel
 	Data.MuzzleVel = ACF.MuzzleVelocity(Data.PropMass, Data.ProjMass + SabotMass, Data.Efficiency)
 	Data.DragCoef  = Data.ProjArea * 0.0001 / Data.ProjMass
 	Data.CartMass  = Data.PropMass + Data.ProjMass + SabotMass

--- a/lua/acf/shared/ammo_types/aphe.lua
+++ b/lua/acf/shared/ammo_types/aphe.lua
@@ -34,17 +34,10 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 
 	ACF.UpdateRoundSpecs(ToolData, Data, GUIData)
 
-	--Volume of the projectile as a cylinder - Volume of the filler * density of steel + Volume of the filler * density of TNT
-	local ProjMass  = math.max(GUIData.ProjVolume - ToolData.FillerMass, 0) * 0.0079 + math.min(ToolData.FillerMass, GUIData.ProjVolume) * ACF.HEDensity
-	local MuzzleVel = ACF.MuzzleVelocity(Data.PropMass, ProjMass, Data.Efficiency)
-	local Energy    = ACF.Kinetic(MuzzleVel * 39.37, ProjMass)
-	local MaxVol    = ACF.RoundShellCapacity(Energy.Momentum, Data.ProjArea, Data.Caliber, Data.ProjLength)
-
-	GUIData.MaxFillerVol = math.Round(math.min(GUIData.ProjVolume, MaxVol * 0.9), 2)
-	GUIData.FillerVol    = math.min(ToolData.FillerMass, GUIData.MaxFillerVol)
-
-	Data.FillerMass = GUIData.FillerVol * ACF.HEDensity
-	Data.ProjMass   = math.max(GUIData.ProjVolume - GUIData.FillerVol, 0) * 0.0079 + Data.FillerMass
+	local FreeVol   = ACF.RoundShellCapacity(Data.PropMass, Data.ProjArea, Data.Caliber, Data.ProjLength)
+	local FillerVol = FreeVol * ToolData.FillerRatio
+	Data.FillerMass = FillerVol * ACF.HEDensity
+	Data.ProjMass   = math.max(GUIData.ProjVolume - FillerVol, 0) * ACF.SteelDensity + Data.FillerMass
 	Data.MuzzleVel  = ACF.MuzzleVelocity(Data.PropMass, Data.ProjMass, Data.Efficiency)
 	Data.DragCoef   = Data.ProjArea * 0.0001 / Data.ProjMass
 	Data.CartMass   = Data.PropMass + Data.ProjMass
@@ -74,10 +67,10 @@ end
 function Ammo:VerifyData(ToolData)
 	Ammo.BaseClass.VerifyData(self, ToolData)
 
-	if not ToolData.FillerMass then
+	if not ToolData.FillerRatio then
 		local Data5 = ToolData.RoundData5
 
-		ToolData.FillerMass = Data5 and tonumber(Data5) or 0
+		ToolData.FillerRatio = Data5 and tonumber(Data5) or 0
 	end
 end
 
@@ -127,18 +120,14 @@ else
 	end
 
 	function Ammo:AddAmmoControls(Base, ToolData, BulletData)
-		local FillerMass = Base:AddSlider("Filler Volume", 0, BulletData.MaxFillerVol, 2)
-		FillerMass:SetClientData("FillerMass", "OnValueChanged")
-		FillerMass:TrackClientData("Projectile")
-		FillerMass:DefineSetter(function(Panel, _, Key, Value)
-			if Key == "FillerMass" then
-				ToolData.FillerMass = math.Round(Value, 2)
+		local FillerRatio = Base:AddSlider("Filler Ratio", 0, 1, 2)
+		FillerRatio:SetClientData("FillerRatio", "OnValueChanged")
+		FillerRatio:DefineSetter(function(Panel, _, Key, Value)
+			if Key == "FillerRatio" then
+				ToolData.FillerRatio = math.Round(Value, 2)
 			end
 
 			self:UpdateRoundData(ToolData, BulletData)
-
-			Panel:SetMax(BulletData.MaxFillerVol)
-			Panel:SetValue(BulletData.FillerVol)
 
 			return BulletData.FillerVol
 		end)
@@ -147,14 +136,14 @@ else
 	function Ammo:AddCrateDataTrackers(Trackers, ...)
 		Ammo.BaseClass.AddCrateDataTrackers(self, Trackers, ...)
 
-		Trackers.FillerMass = true
+		Trackers.FillerRatio = true
 	end
 
 	function Ammo:AddAmmoInformation(Base, ToolData, BulletData)
 		local RoundStats = Base:AddLabel()
 		RoundStats:TrackClientData("Projectile", "SetText")
 		RoundStats:TrackClientData("Propellant")
-		RoundStats:TrackClientData("FillerMass")
+		RoundStats:TrackClientData("FillerRatio")
 		RoundStats:DefineSetter(function()
 			self:UpdateRoundData(ToolData, BulletData)
 
@@ -168,7 +157,7 @@ else
 		end)
 
 		local FillerStats = Base:AddLabel()
-		FillerStats:TrackClientData("FillerMass", "SetText")
+		FillerStats:TrackClientData("FillerRatio", "SetText")
 		FillerStats:DefineSetter(function()
 			self:UpdateRoundData(ToolData, BulletData)
 
@@ -183,7 +172,7 @@ else
 		local PenStats = Base:AddLabel()
 		PenStats:TrackClientData("Projectile", "SetText")
 		PenStats:TrackClientData("Propellant")
-		PenStats:TrackClientData("FillerMass")
+		PenStats:TrackClientData("FillerRatio")
 		PenStats:DefineSetter(function()
 			self:UpdateRoundData(ToolData, BulletData)
 

--- a/lua/acf/shared/ammo_types/aphe.lua
+++ b/lua/acf/shared/ammo_types/aphe.lua
@@ -75,7 +75,7 @@ function Ammo:VerifyData(ToolData)
 end
 
 if SERVER then
-	ACF.AddEntityArguments("acf_ammo", "FillerMass") -- Adding extra info to ammo crates
+	ACF.AddEntityArguments("acf_ammo", "FillerRatio") -- Adding extra info to ammo crates
 
 	function Ammo:OnLast(Entity)
 		Ammo.BaseClass.OnLast(self, Entity)

--- a/lua/acf/shared/ammo_types/aphe.lua
+++ b/lua/acf/shared/ammo_types/aphe.lua
@@ -128,7 +128,7 @@ else
 	function Ammo:AddAmmoControls(Base, ToolData, BulletData)
 		local FillerRatio = Base:AddSlider("Filler Ratio", 0, 1, 2)
 		FillerRatio:SetClientData("FillerRatio", "OnValueChanged")
-		FillerRatio:DefineSetter(function(Panel, _, Key, Value)
+		FillerRatio:DefineSetter(function(_, _, Key, Value)
 			if Key == "FillerRatio" then
 				ToolData.FillerRatio = math.Round(Value, 2)
 			end

--- a/lua/acf/shared/ammo_types/fl.lua
+++ b/lua/acf/shared/ammo_types/fl.lua
@@ -54,7 +54,7 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 	Data.FlechetteSpread   = math.Clamp(ToolData.Spread, Data.MinSpread, Data.MaxSpread)
 	Data.FlechetteCaliber  = self:GetFlechetteCaliber(Data.Caliber, Flechettes)
 	Data.FlechetteArea	   = math.pi * (Data.FlechetteCaliber * 0.5) ^ 2 -- area of a single flechette
-	Data.FlechetteMass	   = Data.FlechetteArea * Data.ProjLength * 0.0079 -- volume of single flechette * density of steel
+	Data.FlechetteMass	   = Data.FlechetteArea * Data.ProjLength * ACF.SteelDensity -- volume of single flechette * density of steel
 	Data.FlechetteDragCoef = Data.FlechetteArea * 0.0001 / Data.FlechetteMass
 	Data.ProjMass		   = Flechettes * Data.FlechetteMass -- total mass of all flechettes
 	Data.DragCoef		   = Data.ProjArea * 0.0001 / Data.ProjMass

--- a/lua/acf/shared/ammo_types/he.lua
+++ b/lua/acf/shared/ammo_types/he.lua
@@ -33,17 +33,10 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 
 	ACF.UpdateRoundSpecs(ToolData, Data, GUIData)
 
-	-- Volume of the projectile as a cylinder - Volume of the filler * density of steel + Volume of the filler * density of TNT
-	local ProjMass  = math.max(GUIData.ProjVolume - ToolData.FillerMass, 0) * 0.0079 + math.min(ToolData.FillerMass, GUIData.ProjVolume) * ACF.HEDensity
-	local MuzzleVel = ACF.MuzzleVelocity(Data.PropMass, ProjMass, Data.Efficiency)
-	local Energy    = ACF.Kinetic(MuzzleVel * 39.37, ProjMass)
-	local MaxVol    = ACF.RoundShellCapacity(Energy.Momentum, Data.ProjArea, Data.Caliber, Data.ProjLength)
-
-	GUIData.MaxFillerVol = math.min(GUIData.ProjVolume, MaxVol)
-	GUIData.FillerVol    = math.min(ToolData.FillerMass, GUIData.MaxFillerVol)
-
-	Data.FillerMass = GUIData.FillerVol * ACF.HEDensity
-	Data.ProjMass   = math.max(GUIData.ProjVolume - GUIData.FillerVol, 0) * 0.0079 + Data.FillerMass
+	local FreeVol   = ACF.RoundShellCapacity(Data.PropMass, Data.ProjArea, Data.Caliber, Data.ProjLength)
+	local FillerVol = FreeVol * ToolData.FillerRatio
+	Data.FillerMass = FillerVol * ACF.HEDensity
+	Data.ProjMass   = math.max(GUIData.ProjVolume - FillerVol, 0) * ACF.SteelDensity + Data.FillerMass
 	Data.MuzzleVel  = ACF.MuzzleVelocity(Data.PropMass, Data.ProjMass, Data.Efficiency)
 	Data.DragCoef   = Data.ProjArea * 0.0001 / Data.ProjMass
 	Data.CartMass   = Data.PropMass + Data.ProjMass
@@ -111,7 +104,7 @@ else
 		local RoundStats = Base:AddLabel()
 		RoundStats:TrackClientData("Projectile", "SetText")
 		RoundStats:TrackClientData("Propellant")
-		RoundStats:TrackClientData("FillerMass")
+		RoundStats:TrackClientData("FillerRatio")
 		RoundStats:DefineSetter(function()
 			self:UpdateRoundData(ToolData, BulletData)
 
@@ -125,7 +118,7 @@ else
 		end)
 
 		local FillerStats = Base:AddLabel()
-		FillerStats:TrackClientData("FillerMass", "SetText")
+		FillerStats:TrackClientData("FillerRatio", "SetText")
 		FillerStats:DefineSetter(function()
 			self:UpdateRoundData(ToolData, BulletData)
 

--- a/lua/acf/shared/ammo_types/heat.lua
+++ b/lua/acf/shared/ammo_types/heat.lua
@@ -332,7 +332,7 @@ else
 
 		local FillerRatio = Base:AddSlider("Filler Ratio", 0, 1, 2)
 		FillerRatio:SetClientData("FillerRatio", "OnValueChanged")
-		FillerRatio:DefineSetter(function(Panel, _, Key, Value)
+		FillerRatio:DefineSetter(function(_, _, Key, Value)
 			if Key == "FillerRatio" then
 				ToolData.FillerRatio = math.Round(Value, 2)
 			end

--- a/lua/acf/shared/ammo_types/heat.lua
+++ b/lua/acf/shared/ammo_types/heat.lua
@@ -72,34 +72,31 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 
 	ACF.UpdateRoundSpecs(ToolData, Data, GUIData)
 
-	local MaxConeAng = math.deg(math.atan((Data.ProjLength - Data.Caliber * 0.02) / (Data.Caliber * 0.5)))
+
+	local FreeVol, FreeLength = ACF.RoundShellCapacity(Data.PropMass, Data.ProjArea, Data.Caliber, Data.ProjLength)
+	local MaxConeAng = math.deg(math.atan((FreeLength - Data.Caliber * 0.02) / (Data.Caliber * 0.5)))
 	local LinerAngle = math.Clamp(ToolData.LinerAngle, GUIData.MinConeAng, MaxConeAng)
 	local _, ConeArea, AirVol = self:ConeCalc(LinerAngle, Data.Caliber * 0.5)
+	local FreeFillerVol = FreeVol - AirVol
 
 	local LinerRad    = math.rad(LinerAngle * 0.5)
 	local SlugCaliber = Data.Caliber - Data.Caliber * (math.sin(LinerRad) * 0.5 + math.cos(LinerRad) * 1.5) * 0.5
 	local SlugArea    = math.pi * (SlugCaliber * 0.5) ^ 2
 	local ConeVol     = ConeArea * Data.Caliber * 0.02
-	local ProjMass    = math.max(GUIData.ProjVolume - ToolData.FillerMass, 0) * 0.0079 + math.min(ToolData.FillerMass, GUIData.ProjVolume) * ACF.HEDensity + ConeVol * 0.0079 --Volume of the projectile as a cylinder - Volume of the filler + Volume of the filler * density of TNT + Area of the cone * thickness * density of steel
-	local MuzzleVel   = ACF.MuzzleVelocity(Data.PropMass, ProjMass, Data.Efficiency)
-	local Energy      = ACF.Kinetic(MuzzleVel * 39.37, ProjMass)
-	local MaxVol      = ACF.RoundShellCapacity(Energy.Momentum, Data.ProjArea, Data.Caliber, Data.ProjLength)
 
-	GUIData.MaxConeAng   = MaxConeAng
-	GUIData.MaxFillerVol = math.max(math.Round(MaxVol - AirVol - ConeVol, 2), GUIData.MinFillerVol)
-	GUIData.FillerVol    = math.Clamp(ToolData.FillerMass, GUIData.MinFillerVol, GUIData.MaxFillerVol)
+	GUIData.MaxConeAng = MaxConeAng
 
 	Data.ConeAng        = LinerAngle
-	Data.FillerMass     = GUIData.FillerVol * ACF.HEDensity
-	Data.ProjMass       = math.max(GUIData.ProjVolume - GUIData.FillerVol - AirVol - ConeVol, 0) * 0.0079 + Data.FillerMass + ConeVol * 0.0079
+	Data.FillerMass     = FreeFillerVol * ToolData.FillerRatio * ACF.HEDensity
+	Data.CasingMass		= (GUIData.ProjVolume - FreeVol) * ACF.SteelDensity
+	Data.ProjMass       = (math.max(FreeFillerVol * (1 - ToolData.FillerRatio), 0) + ConeVol) * ACF.SteelDensity + Data.FillerMass + Data.CasingMass
 	Data.MuzzleVel      = ACF.MuzzleVelocity(Data.PropMass, Data.ProjMass, Data.Efficiency)
-	Data.SlugMass       = ConeVol * 0.0079
+	Data.SlugMass       = ConeVol * ACF.SteelDensity
 	Data.SlugCaliber    = SlugCaliber
 	Data.SlugDragCoef   = SlugArea * 0.0001 / Data.SlugMass
 	Data.BoomFillerMass	= Data.FillerMass * ACF.HEATBoomConvert
 	Data.HEATFillerMass = Data.FillerMass * (1 - ACF.HEATBoomConvert)
 	Data.SlugMV			= self:CalcSlugMV(Data)
-	Data.CasingMass		= Data.ProjMass - Data.FillerMass - ConeVol * 0.0079
 	Data.DragCoef		= Data.ProjArea * 0.0001 / Data.ProjMass
 	Data.CartMass		= Data.PropMass + Data.ProjMass
 
@@ -333,19 +330,14 @@ else
 			return BulletData.ConeAng
 		end)
 
-		local FillerMass = Base:AddSlider("Filler Volume", 0, BulletData.MaxFillerVol, 2)
-		FillerMass:SetClientData("FillerMass", "OnValueChanged")
-		FillerMass:TrackClientData("Projectile")
-		FillerMass:TrackClientData("LinerAngle")
-		FillerMass:DefineSetter(function(Panel, _, Key, Value)
-			if Key == "FillerMass" then
-				ToolData.FillerMass = math.Round(Value, 2)
+		local FillerRatio = Base:AddSlider("Filler Ratio", 0, 1, 2)
+		FillerRatio:SetClientData("FillerRatio", "OnValueChanged")
+		FillerRatio:DefineSetter(function(Panel, _, Key, Value)
+			if Key == "FillerRatio" then
+				ToolData.FillerRatio = math.Round(Value, 2)
 			end
 
 			self:UpdateRoundData(ToolData, BulletData)
-
-			Panel:SetMax(BulletData.MaxFillerVol)
-			Panel:SetValue(BulletData.FillerVol)
 
 			return BulletData.FillerVol
 		end)
@@ -354,7 +346,7 @@ else
 	function Ammo:AddCrateDataTrackers(Trackers, ...)
 		Ammo.BaseClass.AddCrateDataTrackers(self, Trackers, ...)
 
-		Trackers.FillerMass = true
+		Trackers.FillerRatio = true
 		Trackers.LinerAngle = true
 	end
 
@@ -362,7 +354,7 @@ else
 		local RoundStats = Base:AddLabel()
 		RoundStats:TrackClientData("Projectile", "SetText")
 		RoundStats:TrackClientData("Propellant")
-		RoundStats:TrackClientData("FillerMass")
+		RoundStats:TrackClientData("FillerRatio")
 		RoundStats:TrackClientData("LinerAngle")
 		RoundStats:DefineSetter(function()
 			self:UpdateRoundData(ToolData, BulletData)
@@ -377,7 +369,7 @@ else
 		end)
 
 		local FillerStats = Base:AddLabel()
-		FillerStats:TrackClientData("FillerMass", "SetText")
+		FillerStats:TrackClientData("FillerRatio", "SetText")
 		FillerStats:TrackClientData("LinerAngle")
 		FillerStats:DefineSetter(function()
 			self:UpdateRoundData(ToolData, BulletData)
@@ -393,7 +385,7 @@ else
 		local Penetrator = Base:AddLabel()
 		Penetrator:TrackClientData("Projectile", "SetText")
 		Penetrator:TrackClientData("Propellant")
-		Penetrator:TrackClientData("FillerMass")
+		Penetrator:TrackClientData("FillerRatio")
 		Penetrator:TrackClientData("LinerAngle")
 		Penetrator:DefineSetter(function()
 			self:UpdateRoundData(ToolData, BulletData)
@@ -409,7 +401,7 @@ else
 		local PenStats = Base:AddLabel()
 		PenStats:TrackClientData("Projectile", "SetText")
 		PenStats:TrackClientData("Propellant")
-		PenStats:TrackClientData("FillerMass")
+		PenStats:TrackClientData("FillerRatio")
 		PenStats:TrackClientData("LinerAngle")
 		PenStats:DefineSetter(function()
 			self:UpdateRoundData(ToolData, BulletData)

--- a/lua/acf/shared/ammo_types/heatfs.lua
+++ b/lua/acf/shared/ammo_types/heatfs.lua
@@ -15,34 +15,30 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 
 	ACF.UpdateRoundSpecs(ToolData, Data, GUIData)
 
-	local MaxConeAng = math.deg(math.atan((Data.ProjLength - Data.Caliber * 0.02) / (Data.Caliber * 0.5)))
+	local FreeVol, FreeLength = ACF.RoundShellCapacity(Data.PropMass, Data.ProjArea, Data.Caliber, Data.ProjLength)
+	local MaxConeAng = math.deg(math.atan((FreeLength - Data.Caliber * 0.02) / (Data.Caliber * 0.5)))
 	local LinerAngle = math.Clamp(ToolData.LinerAngle, GUIData.MinConeAng, MaxConeAng)
 	local _, ConeArea, AirVol = self:ConeCalc(LinerAngle, Data.Caliber * 0.5)
+	local FreeFillerVol = FreeVol - AirVol
 
 	local LinerRad    = math.rad(LinerAngle * 0.5)
 	local SlugCaliber = Data.Caliber - Data.Caliber * (math.sin(LinerRad) * 0.5 + math.cos(LinerRad) * 1.5) * 0.5
 	local SlugArea    = math.pi * (SlugCaliber * 0.5) ^ 2
 	local ConeVol     = ConeArea * Data.Caliber * 0.02
-	local ProjMass    = math.max(GUIData.ProjVolume - ToolData.FillerMass, 0) * 0.0079 + math.min(ToolData.FillerMass, GUIData.ProjVolume) * ACF.HEDensity + ConeVol * 0.0079 --Volume of the projectile as a cylinder - Volume of the filler - Volume of the crush cone * density of steel + Volume of the filler * density of TNT + Area of the cone * thickness * density of steel
-	local MuzzleVel   = ACF.MuzzleVelocity(Data.PropMass, ProjMass, Data.Efficiency)
-	local Energy      = ACF.Kinetic(MuzzleVel * 39.37, ProjMass)
-	local MaxVol      = ACF.RoundShellCapacity(Energy.Momentum, Data.ProjArea, Data.Caliber, Data.ProjLength)
 
-	GUIData.MaxConeAng   = MaxConeAng
-	GUIData.MaxFillerVol = math.max(math.Round(MaxVol - AirVol - ConeVol, 2), GUIData.MinFillerVol)
-	GUIData.FillerVol    = math.Clamp(ToolData.FillerMass, GUIData.MinFillerVol, GUIData.MaxFillerVol)
+	GUIData.MaxConeAng = MaxConeAng
 
 	Data.ConeAng        = LinerAngle
-	Data.FillerMass     = GUIData.FillerVol * ACF.HEDensity
-	Data.ProjMass       = math.max(GUIData.ProjVolume - GUIData.FillerVol - AirVol - ConeVol, 0) * 0.0079 + Data.FillerMass + ConeVol * 0.0079
+	Data.FillerMass     = FreeFillerVol * ToolData.FillerRatio * ACF.HEDensity
+	Data.CasingMass		= (GUIData.ProjVolume - FreeVol) * ACF.SteelDensity
+	Data.ProjMass       = (math.max(FreeFillerVol * (1 - ToolData.FillerRatio), 0) + ConeVol) * ACF.SteelDensity + Data.FillerMass + Data.CasingMass
 	Data.MuzzleVel      = ACF.MuzzleVelocity(Data.PropMass, Data.ProjMass, Data.Efficiency) * 1.25
-	Data.SlugMass       = ConeVol * 0.0079
+	Data.SlugMass       = ConeVol * ACF.SteelDensity
 	Data.SlugCaliber    = SlugCaliber
 	Data.SlugDragCoef   = SlugArea * 0.0001 / Data.SlugMass
 	Data.BoomFillerMass	= Data.FillerMass * ACF.HEATBoomConvert
 	Data.HEATFillerMass = Data.FillerMass * (1 - ACF.HEATBoomConvert)
 	Data.SlugMV			= self:CalcSlugMV(Data)
-	Data.CasingMass		= Data.ProjMass - Data.FillerMass - ConeVol * 0.0079
 	Data.DragCoef		= Data.ProjArea * 0.0001 / Data.ProjMass
 	Data.CartMass		= Data.PropMass + Data.ProjMass
 

--- a/lua/acf/shared/ammo_types/hp.lua
+++ b/lua/acf/shared/ammo_types/hp.lua
@@ -26,18 +26,13 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 
 	ACF.UpdateRoundSpecs(ToolData, Data, GUIData)
 
-	local ProjMass     = math.max(GUIData.ProjVolume * 0.5, 0) * 0.0079 --(Volume of the projectile as a cylinder - Volume of the cavity) * density of steel 
-	local MuzzleVel    = ACF.MuzzleVelocity(Data.PropMass, ProjMass, Data.Efficiency)
-	local Energy       = ACF.Kinetic(MuzzleVel * 39.37, ProjMass)
-	local MaxVol       = ACF.RoundShellCapacity(Energy.Momentum, Data.ProjArea, Data.Caliber, Data.ProjLength)
-	local MaxCavity    = math.min(GUIData.ProjVolume, MaxVol)
-	local HollowCavity = math.Clamp(ToolData.HollowCavity, GUIData.MinCavVol, MaxCavity)
+	local FreeVol      = ACF.RoundShellCapacity(Data.PropMass, Data.ProjArea, Data.Caliber, Data.ProjLength)
+	local MaxCavity    = math.min(GUIData.ProjVolume, FreeVol)
+	local HollowCavity = FreeVol * ToolData.HollowCavity
 	local ExpRatio     = HollowCavity / GUIData.ProjVolume
 
-	GUIData.MaxCavVol = MaxCavity
-
 	Data.CavVol     = HollowCavity
-	Data.ProjMass   = (Data.ProjArea * Data.ProjLength - HollowCavity) * 0.0079 --Volume of the projectile as a cylinder * fraction missing due to hollow point (Data5) * density of steel
+	Data.ProjMass   = (Data.ProjArea * Data.ProjLength - HollowCavity) * ACF.SteelDensity --Volume of the projectile as a cylinder * fraction missing due to hollow point (Data5) * density of steel
 	Data.MuzzleVel  = ACF.MuzzleVelocity(Data.PropMass, Data.ProjMass, Data.Efficiency)
 	Data.ShovePower = 0.2 + ExpRatio * 0.5
 	Data.Diameter   = Data.Caliber + ExpRatio * Data.ProjLength
@@ -103,18 +98,14 @@ else
 	ACF.RegisterAmmoDecal("HP", "damage/ap_pen", "damage/ap_rico")
 
 	function Ammo:AddAmmoControls(Base, ToolData, BulletData)
-		local HollowCavity = Base:AddSlider("Cavity Volume", BulletData.MinCavVol, BulletData.MaxCavVol, 2)
+		local HollowCavity = Base:AddSlider("Cavity Ratio", 0, 1, 2)
 		HollowCavity:SetClientData("HollowCavity", "OnValueChanged")
-		HollowCavity:TrackClientData("Projectile")
 		HollowCavity:DefineSetter(function(Panel, _, Key, Value)
 			if Key == "HollowCavity" then
 				ToolData.HollowCavity = math.Round(Value, 2)
 			end
 
 			self:UpdateRoundData(ToolData, BulletData)
-
-			Panel:SetMax(BulletData.MaxCavVol)
-			Panel:SetValue(BulletData.CavVol)
 
 			return BulletData.CavVol
 		end)

--- a/lua/acf/shared/ammo_types/hp.lua
+++ b/lua/acf/shared/ammo_types/hp.lua
@@ -27,7 +27,6 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 	ACF.UpdateRoundSpecs(ToolData, Data, GUIData)
 
 	local FreeVol      = ACF.RoundShellCapacity(Data.PropMass, Data.ProjArea, Data.Caliber, Data.ProjLength)
-	local MaxCavity    = math.min(GUIData.ProjVolume, FreeVol)
 	local HollowCavity = FreeVol * ToolData.HollowCavity
 	local ExpRatio     = HollowCavity / GUIData.ProjVolume
 
@@ -100,7 +99,7 @@ else
 	function Ammo:AddAmmoControls(Base, ToolData, BulletData)
 		local HollowCavity = Base:AddSlider("Cavity Ratio", 0, 1, 2)
 		HollowCavity:SetClientData("HollowCavity", "OnValueChanged")
-		HollowCavity:DefineSetter(function(Panel, _, Key, Value)
+		HollowCavity:DefineSetter(function(_, _, Key, Value)
 			if Key == "HollowCavity" then
 				ToolData.HollowCavity = math.Round(Value, 2)
 			end

--- a/lua/acf/shared/ammo_types/refill.lua
+++ b/lua/acf/shared/ammo_types/refill.lua
@@ -12,7 +12,7 @@ function Ammo:GetDisplayData()
 end
 
 function Ammo:BaseConvert(ToolData)
-	local ProjMass = 5.5 * 0.079
+	local ProjMass = 5.5 * ACF.SteelDensity
 	local PropMass = 0.001
 
 	return {

--- a/lua/acf/shared/ammo_types/smoke.lua
+++ b/lua/acf/shared/ammo_types/smoke.lua
@@ -93,7 +93,7 @@ function Ammo:VerifyData(ToolData)
 end
 
 if SERVER then
-	ACF.AddEntityArguments("acf_ammo", "SmokeFiller", "WPFiller") -- Adding extra info to ammo crates
+	ACF.AddEntityArguments("acf_ammo", "FillerRatio", "SmokeWPRatio") -- Adding extra info to ammo crates
 
 	function Ammo:OnLast(Entity)
 		Ammo.BaseClass.OnLast(self, Entity)

--- a/lua/acf/shared/ammo_types/smoke.lua
+++ b/lua/acf/shared/ammo_types/smoke.lua
@@ -178,7 +178,7 @@ else
 	function Ammo:AddAmmoControls(Base, ToolData, BulletData)
 		local FillerRatio = Base:AddSlider("Filler Ratio", 0, 1, 2)
 		FillerRatio:SetClientData("FillerRatio", "OnValueChanged")
-		FillerRatio:DefineSetter(function(Panel, _, Key, Value, IsTracked)
+		FillerRatio:DefineSetter(function(_, _, Key, Value)
 			if Key == "FillerRatio" then
 				ToolData.FillerRatio = math.Round(Value, 2)
 			end
@@ -190,7 +190,7 @@ else
 
 		local SmokeWPRatio = Base:AddSlider("Smoke/WP Ratio", 0, 1, 2)
 		SmokeWPRatio:SetClientData("SmokeWPRatio", "OnValueChanged")
-		SmokeWPRatio:DefineSetter(function(Panel, _, Key, Value, IsTracked)
+		SmokeWPRatio:DefineSetter(function(_, _, Key, Value)
 			if Key == "SmokeWPRatio" then
 				ToolData.SmokeWPRatio = math.Round(Value, 2)
 			end


### PR DESCRIPTION
- Available filler volume is now based on propellant mass and shell area (as opposed to muzzle velocity), which is more logical and simplifies shell updates by a lot. Available volume is generally unchanged, the results are almost the same.
- Filler sliders changed to ratios instead of volume. 1 means 100% of the volume is used for filler, 0.9 means 90% is for filler, 10% for steel. Changing the projectile or propellant length slider no longer has any effect on the filler sliders, which improves QoL.

Here is smoke for example:
![image](https://user-images.githubusercontent.com/37046867/115119225-2f78e280-9f9f-11eb-8463-2815d2078604.png)

Filler ratio at 1 means 100% of available volume is used for filler. Smoke/WP ratio at 0.5 means that volume is split 50/50 between smoke and white phosporous.

This applies to HE, APHE, HEAT, HEATFS, HP and smoke (and flares and GLATGMs, in a separate pull request)