### PR TITLE
Fix Proper Clipping mass armor values changing.

### DIFF
--- a/lua/weapons/gmod_tool/stools/acfarmorprop.lua
+++ b/lua/weapons/gmod_tool/stools/acfarmorprop.lua
@@ -226,15 +226,8 @@ else -- Serverside-only stuff
 		if not IsValid(PhysObj) then return end
 
 		local Ductility = Entity.ACF.Ductility
-		local Thickness = Entity.ACF.MaxArmour
-
-		ACF.Check(Entity) -- We need to update again to get the Area
-
-		local Area = Entity.ACF.Area
-		local Mass = CalcArmor(Area, Ductility, Thickness)
 
 		ApplySettings(_, Entity, {
-			Mass = Mass,
 			Ductility = Ductility * 100,
 		})
 	end


### PR DESCRIPTION
Instead of changing the mass to fit the health and armor, change those instead. (I've got no clue how this is supposed to work but it seems to work fine)
Fixes #173 and https://github.com/DaDamRival/proper_clipping/issues/24