### PR TITLE
HEAT rework

### DIFF
--- a/lua/acf/base/acf_globals.lua
+++ b/lua/acf/base/acf_globals.lua
@@ -69,9 +69,20 @@ do -- ACF global vars
 
 	-- HE
 	ACF.HEPower            = 8000 --HE Filler power per KG in KJ
-	ACF.HEDensity          = 0.00165 -- Density of TNT in kg/cm3
+	ACF.HEDensity          = 1.65e-3 -- Density of TNT in kg/cm3
 	ACF.HEFrag             = 1000 --Mean fragment number for equal weight TNT and casing
-	ACF.HEATMVScale        = 0.75 --Filler KE to HEAT slug KE conversion expotential
+
+	-- HEAT
+	ACF.TNTPower           = 4184    -- J/g
+	ACF.CompBDensity       = 1.72e-3 -- kg/cm^3
+	ACF.CompBEquivalent    = 1.33    -- Relative to TNT
+	ACF.OctolDensity       = 1.83e-3 -- kg/cm^3
+	ACF.OctolEquivalent    = 1.54    -- Relative to TNT
+	ACF.LinerThicknessMult = 0.12    -- Metal liner thickness multiplier
+	ACF.MaxChargeHeadLen   = 1.5     -- Maximum shaped charge head length (in charge diameters), lengths above will incur diminishing returns
+	ACF.HEATPenMul         = 0.4     -- Linear jet penetration multiplier
+	ACF.HEATMinPenVel      = 1000    -- m/s, minimum velocity of the copper jet that contributes to penetration
+	ACF.HEATMVScale        = 0.75    --Filler KE to HEAT slug KE conversion expotential
 	ACF.HEATMulAmmo        = 30 --HEAT slug damage multiplier; 13.2x roughly equal to AP damage
 	ACF.HEATMulFuel        = 4 --needs less multiplier, much less health than ammo
 	ACF.HEATMulEngine      = 10 --likewise
@@ -79,8 +90,9 @@ do -- ACF global vars
 	ACF.HEATBoomConvert    = 1 / 3 -- percentage of filler that creates HE damage at detonation
 
 	-- Material densities
-	ACF.SteelDensity       = 7.9e-3	-- kg/cm^3
-	ACF.AluminumDensity    = 2.7e-3	-- kg/cm^3
+	ACF.SteelDensity       = 7.9e-3	 -- kg/cm^3
+	ACF.AluminumDensity    = 2.7e-3	 -- kg/cm^3
+	ACF.CopperDensity      = 8.96e-3 -- kg/cm^3
 
 	-- Debris
 	ACF.ChildDebris        = 50 -- higher is more debris props; Chance = ACF.ChildDebris / num_children; Only applies to children of acf-killed parent props

--- a/lua/acf/base/acf_globals.lua
+++ b/lua/acf/base/acf_globals.lua
@@ -78,9 +78,9 @@ do -- ACF global vars
 	ACF.CompBEquivalent    = 1.33    -- Relative to TNT
 	ACF.OctolDensity       = 1.83e-3 -- kg/cm^3
 	ACF.OctolEquivalent    = 1.54    -- Relative to TNT
-	ACF.LinerThicknessMult = 0.12    -- Metal liner thickness multiplier
+	ACF.LinerThicknessMult = 0.07    -- Metal liner thickness multiplier
 	ACF.MaxChargeHeadLen   = 1.5     -- Maximum shaped charge head length (in charge diameters), lengths above will incur diminishing returns
-	ACF.HEATPenMul         = 0.4     -- Linear jet penetration multiplier
+	ACF.HEATPenMul         = 1.1     -- Linear jet penetration multiplier
 	ACF.HEATMinPenVel      = 1000    -- m/s, minimum velocity of the copper jet that contributes to penetration
 	ACF.HEATCavityMul      = 1.2     -- Size of the penetration cavity in penetrator volume expended
 	ACF.HEATSpallingArc    = 0.5     -- Cossine of the HEAT spalling angle

--- a/lua/acf/base/acf_globals.lua
+++ b/lua/acf/base/acf_globals.lua
@@ -83,7 +83,7 @@ do -- ACF global vars
 	ACF.HEATPenMul         = 0.4     -- Linear jet penetration multiplier
 	ACF.HEATMinPenVel      = 1000    -- m/s, minimum velocity of the copper jet that contributes to penetration
 	ACF.HEATCavityMul      = 1.2     -- Size of the penetration cavity in penetrator volume expended
-	ACF.HEATSpallingArc    = 0.85    -- Cossine of the HEAT spalling angle
+	ACF.HEATSpallingArc    = 0.5     -- Cossine of the HEAT spalling angle
 	ACF.HEATBoomConvert    = 1 / 3   -- Percentage of filler that creates HE damage at detonation
 
 	-- Material densities

--- a/lua/acf/base/acf_globals.lua
+++ b/lua/acf/base/acf_globals.lua
@@ -83,6 +83,7 @@ do -- ACF global vars
 	ACF.HEATPenMul         = 0.4     -- Linear jet penetration multiplier
 	ACF.HEATMinPenVel      = 1000    -- m/s, minimum velocity of the copper jet that contributes to penetration
 	ACF.HEATCavityMul      = 1.2     -- Size of the penetration cavity in penetrator volume expended
+	ACF.HEATSpallingArc    = 0.85    -- Cossine of the HEAT spalling angle
 	ACF.HEATBoomConvert    = 1 / 3   -- Percentage of filler that creates HE damage at detonation
 
 	-- Material densities

--- a/lua/acf/base/acf_globals.lua
+++ b/lua/acf/base/acf_globals.lua
@@ -82,16 +82,13 @@ do -- ACF global vars
 	ACF.MaxChargeHeadLen   = 1.5     -- Maximum shaped charge head length (in charge diameters), lengths above will incur diminishing returns
 	ACF.HEATPenMul         = 0.4     -- Linear jet penetration multiplier
 	ACF.HEATMinPenVel      = 1000    -- m/s, minimum velocity of the copper jet that contributes to penetration
-	ACF.HEATMVScale        = 0.75    --Filler KE to HEAT slug KE conversion expotential
-	ACF.HEATMulAmmo        = 30 --HEAT slug damage multiplier; 13.2x roughly equal to AP damage
-	ACF.HEATMulFuel        = 4 --needs less multiplier, much less health than ammo
-	ACF.HEATMulEngine      = 10 --likewise
-	ACF.HEATPenLayerMul    = 0.75 --HEAT base energy multiplier
-	ACF.HEATBoomConvert    = 1 / 3 -- percentage of filler that creates HE damage at detonation
+	ACF.HEATCavityMul      = 1.2     -- Size of the penetration cavity in penetrator volume expended
+	ACF.HEATBoomConvert    = 1 / 3   -- Percentage of filler that creates HE damage at detonation
 
 	-- Material densities
-	ACF.SteelDensity       = 7.9e-3	 -- kg/cm^3
-	ACF.AluminumDensity    = 2.7e-3	 -- kg/cm^3
+	ACF.SteelDensity       = 7.9e-3  -- kg/cm^3
+	ACF.RHADensity         = 7.84e-3 -- kg/cm^3
+	ACF.AluminumDensity    = 2.7e-3  -- kg/cm^3
 	ACF.CopperDensity      = 8.96e-3 -- kg/cm^3
 
 	-- Debris

--- a/lua/acf/server/ballistics.lua
+++ b/lua/acf/server/ballistics.lua
@@ -338,6 +338,7 @@ do -- Terminal ballistics --------------------------
 
 		return Vec - (2 * Vec:Dot(HitNormal)) * HitNormal
 	end
+	ACF_RicochetVector = RicochetVector
 
 	function ACF_VolumeDamage(Bullet, Trace, Volume)
 		local HitRes = ACF.Damage(Bullet, Trace, Volume)
@@ -348,6 +349,24 @@ do -- Terminal ballistics --------------------------
 		end
 	end
 
+	function ACF_CalcRicochet(Bullet, Trace)
+		local HitAngle = ACF_GetHitAngle(Trace.HitNormal, Bullet.Flight)
+		-- Ricochet distribution center
+		local sigmoidCenter = Bullet.DetonatorAngle or (Bullet.Ricochet - math.abs(Bullet.Speed / 39.37 - Bullet.LimitVel) / 100)
+
+		-- Ricochet probability (sigmoid distribution); up to 5% minimal ricochet probability for projectiles with caliber < 20 mm
+		local ricoProb = math.Clamp(1 / (1 + math.exp((HitAngle - sigmoidCenter) / -4)), math.max(-0.05 * (Bullet.Caliber - 2) / 2, 0), 1)
+
+		-- Checking for ricochet
+		local Ricochet = 0
+		local Loss     = 0
+		if ricoProb > math.random() and HitAngle < 90 then
+			Ricochet = math.Clamp(HitAngle / 90, 0.05, 1) -- atleast 5% of energy is kept
+			Loss     = 0.25 - Ricochet
+		end
+		return Ricochet, Loss
+	end
+
 	function ACF_RoundImpact(Bullet, Trace)
 		local Speed    = Bullet.Speed
 		local Energy   = Bullet.Energy
@@ -355,18 +374,7 @@ do -- Terminal ballistics --------------------------
 		local Ricochet = 0
 
 		if HitRes.Loss == 1 then
-			local HitAngle = ACF_GetHitAngle(Trace.HitNormal, Bullet.Flight)
-			-- Ricochet distribution center
-			local sigmoidCenter = Bullet.DetonatorAngle or (Bullet.Ricochet - math.abs(Speed / 39.37 - Bullet.LimitVel) / 100)
-
-			-- Ricochet probability (sigmoid distribution); up to 5% minimal ricochet probability for projectiles with caliber < 20 mm
-			local ricoProb = math.Clamp(1 / (1 + math.exp((HitAngle - sigmoidCenter) / -4)), math.max(-0.05 * (Bullet.Caliber - 2) / 2, 0), 1)
-
-			-- Checking for ricochet
-			if ricoProb > math.random() and HitAngle < 90 then
-				Ricochet    = math.Clamp(HitAngle / 90, 0.05, 1) -- atleast 5% of energy is kept
-				HitRes.Loss = 0.25 - Ricochet
-			end
+			Ricochet, HitRes.Loss = ACF_CalcRicochet(Bullet, Trace)
 		end
 
 		if ACF.KEPush then

--- a/lua/acf/server/ballistics.lua
+++ b/lua/acf/server/ballistics.lua
@@ -339,6 +339,15 @@ do -- Terminal ballistics --------------------------
 		return Vec - (2 * Vec:Dot(HitNormal)) * HitNormal
 	end
 
+	function ACF_VolumeDamage(Bullet, Trace, Volume)
+		local HitRes = ACF.Damage(Bullet, Trace, Volume)
+
+		if HitRes.Kill then
+			local Debris = ACF_APKill(Trace.Entity, Bullet.Flight:GetNormalized() , Energy.Kinetic)
+			table.insert(Bullet.Filter , Debris)
+		end
+	end
+
 	function ACF_RoundImpact(Bullet, Trace)
 		local Speed    = Bullet.Speed
 		local Energy   = Bullet.Energy
@@ -488,6 +497,8 @@ do -- Terminal ballistics --------------------------
 			end
 		end
 	end
+
+	ACF_DigTrace = DigTrace
 
 	function ACF_PenetrateMapEntity(Bullet, Trace)
 		local Surface = util.GetSurfaceData(Trace.SurfaceProps)

--- a/lua/acf/server/ballistics.lua
+++ b/lua/acf/server/ballistics.lua
@@ -343,7 +343,7 @@ do -- Terminal ballistics --------------------------
 		local HitRes = ACF.Damage(Bullet, Trace, Volume)
 
 		if HitRes.Kill then
-			local Debris = ACF_APKill(Trace.Entity, Bullet.Flight:GetNormalized() , Energy.Kinetic)
+			local Debris = ACF_APKill(Trace.Entity, Bullet.Flight:GetNormalized(), 0)
 			table.insert(Bullet.Filter , Debris)
 		end
 	end

--- a/lua/acf/shared/ammo_types/heat.lua
+++ b/lua/acf/shared/ammo_types/heat.lua
@@ -216,7 +216,6 @@ if SERVER then
 				end
 			end
 		end
-		PrintTable(Squishies)
 
 		-- Move the jet start to the impact point and back it up by the passive standoff
 		local Direction = Bullet.Flight:GetNormalized()
@@ -331,15 +330,14 @@ if SERVER then
 			-- Minimum area is the base of the spalling cone, with the distance being the average squishy distance
 			-- Divided by the average distance squared so it's the same as the relative area
 			local MinArea = Radius * Radius * math.pi / (AvgDist * AvgDist)
-			print(AreaSum, MinArea)
 			AreaSum = math.max(AreaSum, MinArea)
+			-- The only information used from the trace is the entity, so we can use a fake TraceRes with placeholder information,
+			--  which the damage function checks but doesn't use. Scuffed, but alas - rework damage
+			local FakeTrace = {HitNormal = Vector(1,0,0), StartPos = Vector(1,0,0), HitPos = Vector(0,0,0), EndPos = Vector(0,0,0)}
 			for _, v in ipairs(Damageables) do
-				-- The only information used from the trace is the entity, so we can use a fake TraceRes
-				-- Scuffed, but alas
-				local FakeTrace = {HitNormal = Vector(1,0,0), Entity = v[1]}
+				FakeTrace.Entity = v[1]
 				-- Damage is proportional to how much relative surface area the target occupies from the jet's POV
 				local Damage    = Cavity * v[2] / AreaSum
-				print(Cavity, v[2], AreaSum)
 				ACF_VolumeDamage(Bullet, FakeTrace, Damage)
 			end
 
@@ -528,7 +526,6 @@ else
 			return Text:format(Blast, BulletData.Fragments, FragMass, FragVel)
 		end)
 
-		-- TODO this should prolly be removed
 		local Penetrator = Base:AddLabel()
 		Penetrator:TrackClientData("Projectile", "SetText")
 		Penetrator:TrackClientData("Propellant")
@@ -546,7 +543,6 @@ else
 			return Text:format(CuMass, JetMass, MinVel, MaxVel)
 		end)
 
-		-- TODO add pen stats at passive standoff + maybe max pen
 		local PenStats = Base:AddLabel()
 		PenStats:TrackClientData("Projectile", "SetText")
 		PenStats:TrackClientData("Propellant")
@@ -563,8 +559,5 @@ else
 
 			return Text:format(Standoff1, Pen1, Standoff2, Pen2)
 		end)
-
-		-- TODO remove this?
-		Base:AddLabel("Note: The penetration range data is an approximation and may not be entirely accurate.")
 	end
 end

--- a/lua/acf/shared/ammo_types/heat.lua
+++ b/lua/acf/shared/ammo_types/heat.lua
@@ -317,7 +317,9 @@ if SERVER then
 						-- Divided by the distance because far away things seem smaller, mult'd by the dot product because
 						--  spalling is concentrated around the main jet, and divided by 6 because (simplifying the target
 						--  as a cube, good enough) one of the 6 faces is visible
-						local RelArea = (DotProd ^ 3) * Ent.ACF.Area / (DistSqr * 6)
+						local Area    = 0
+						if ACF.Check(Ent) then Area = Ent.ACF.Area else continue end
+						local RelArea = (DotProd ^ 3) * Area / (DistSqr * 6)
 						AreaSum = AreaSum + RelArea
 						AvgDist = AvgDist + math.sqrt(DistSqr)
 						Damageables[#Damageables + 1] = {Ent, RelArea}

--- a/lua/acf/shared/ammo_types/heatfs.lua
+++ b/lua/acf/shared/ammo_types/heatfs.lua
@@ -43,7 +43,7 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 
 	-- At lower cone angles, the explosive crushes the cone inward, expelling a jet. The steeper the cone, the faster the jet, but the less mass expelled
 	local MinVelMult = (0.99 - 0.6) * LinerAngle / 90 + 0.6
-	local JetMass    = LinerMass * ((1 - 0.25)* LinerAngle / 90  + 0.25)
+	local JetMass    = LinerMass * ((1 - 0.25) * LinerAngle / 90  + 0.25)
 	local JetAvgVel  = (2 * FillerEnergy / JetMass) ^ 0.5  -- Average velocity of the copper jet
 	local JetMinVel  = JetAvgVel * MinVelMult              -- Minimum velocity of the jet (the rear)
 	-- Calculates the maximum velocity, considering the velocity distribution is linear from the rear to the tip (integrated this by hand, pain :) )

--- a/lua/acf/shared/ammo_types/heatfs.lua
+++ b/lua/acf/shared/ammo_types/heatfs.lua
@@ -35,20 +35,22 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 	local FrontFillVol = FreeVol * ConeLength / FreeLength - ConeVol -- Volume of explosive sorounding the liner
 	local RearFillVol  = FreeVol * RearFillLen / FreeLength -- Volume behind the liner
 	local EquivFillVol = FreeVol * EquivFillLen / FreeLength + FrontFillVol -- Equivalent total explosive volume
-	local FillerEnergy = EquivFillVol * ACF.OctolDensity * 1e3 * ACF.TNTPower * ACF.OctolEquivalent
+	local LengthPct    = Data.ProjLength / (Data.MaxProjLength or Data.ProjLength * 2)
+	local OverEnergy   = math.min(math.Remap(LengthPct, 0.6, 1, 1, 0.3), 1)
+	local FillerEnergy = OverEnergy * EquivFillVol * ACF.CompBDensity * 1e3 * ACF.TNTPower * ACF.CompBEquivalent
 	local FillerVol    = FrontFillVol + RearFillVol
 	local FillerMass   = FillerVol * ACF.OctolDensity
 
 	-- At lower cone angles, the explosive crushes the cone inward, expelling a jet. The steeper the cone, the faster the jet, but the less mass expelled
-	local MinVelMult = (0.98 - 0.6) * LinerAngle / 90 + 0.6
-	local JetMass    = LinerMass * ((1 - 0.8)* LinerAngle / 90  + 0.8)
+	local MinVelMult = (0.99 - 0.6) * LinerAngle / 90 + 0.6
+	local JetMass    = LinerMass * ((1 - 0.25)* LinerAngle / 90  + 0.25)
 	local JetAvgVel  = (2 * FillerEnergy / JetMass) ^ 0.5  -- Average velocity of the copper jet
 	local JetMinVel  = JetAvgVel * MinVelMult              -- Minimum velocity of the jet (the rear)
 	-- Calculates the maximum velocity, considering the velocity distribution is linear from the rear to the tip (integrated this by hand, pain :) )
 	local JetMaxVel  = 0.5 * (3 ^ 0.5 * (8 * FillerEnergy - JetMass * JetMinVel ^ 2) ^ 0.5 / JetMass ^ 0.5 - JetMinVel) -- Maximum velocity of the jet (the tip)
 
 	-- Both the "magic numbers" are unitless, tuning constants that were used to fit the breakup time to real world values, I suggest they not be messed with
-	local BreakupTime    = 1.6e-6 * (5e9 * JetMass / (JetMaxVel - JetMinVel)) ^ 0.3333  -- Jet breakup time in seconds
+	local BreakupTime    = 2.6e-6 * (5e9 * JetMass / (JetMaxVel - JetMinVel)) ^ 0.3333  -- Jet breakup time in seconds
 	local BreakupDist    = JetMaxVel * BreakupTime
 
 	GUIData.MinConeAng = MinConeAng

--- a/lua/acf/shared/ammo_types/heatfs.lua
+++ b/lua/acf/shared/ammo_types/heatfs.lua
@@ -85,5 +85,31 @@ if SERVER then
 		Entity:SetNW2String("AmmoType", "HEATFS")
 	end
 else
+	function Ammo:AddAmmoControls(Base, ToolData, BulletData)
+		local LinerAngle = Base:AddSlider("Liner Angle", BulletData.MinConeAng, 90, 1)
+		LinerAngle:SetClientData("LinerAngle", "OnValueChanged")
+		LinerAngle:TrackClientData("Projectile")
+		LinerAngle:DefineSetter(function(Panel, _, Key, Value)
+			if Key == "LinerAngle" then
+				ToolData.LinerAngle = math.Round(Value, 2)
+			end
 
+			self:UpdateRoundData(ToolData, BulletData)
+
+			Panel:SetMin(BulletData.MinConeAng)
+			Panel:SetValue(BulletData.ConeAng)
+
+			return BulletData.ConeAng
+		end)
+
+		local StandoffRatio = Base:AddSlider("Extra Standoff Ratio", 0, 0.75, 2)
+		StandoffRatio:SetClientData("StandoffRatio", "OnValueChanged")
+		StandoffRatio:DefineSetter(function(_, _, _, Value)
+			ToolData.StandoffRatio = math.Round(Value, 2)
+
+			self:UpdateRoundData(ToolData, BulletData)
+
+			return ToolData.StandoffRatio
+		end)
+	end
 end

--- a/lua/acf/shared/ammo_types/heatfs.lua
+++ b/lua/acf/shared/ammo_types/heatfs.lua
@@ -4,7 +4,7 @@ function Ammo:OnLoaded()
 	Ammo.BaseClass.OnLoaded(self)
 
 	self.Name		 = "High Explosive Anti-Tank Fin Stabilized"
-	self.Description = "An improved HEAT round with higher penetration and muzzle velocity."
+	self.Description = "An improved HEAT round with better standoff and explosive power."
 	self.Blacklist = ACF.GetWeaponBlacklist({
 		SB = true,
 	})
@@ -15,31 +15,59 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 
 	ACF.UpdateRoundSpecs(ToolData, Data, GUIData)
 
-	local FreeVol, FreeLength = ACF.RoundShellCapacity(Data.PropMass, Data.ProjArea, Data.Caliber, Data.ProjLength)
-	local MaxConeAng  = math.deg(math.atan((FreeLength - Data.Caliber * 0.02) / (Data.Caliber * 0.5)))
-	local LinerAngle  = math.Clamp(ToolData.LinerAngle, GUIData.MinConeAng, MaxConeAng)
-	local FillerRatio = math.Clamp(ToolData.FillerRatio, 0, 1)
-	local _, ConeArea, AirVol = self:ConeCalc(LinerAngle, Data.Caliber * 0.5)
-	local FreeFillerVol = FreeVol - AirVol
+	local CapLength       = GUIData.MinProjLength * 0.5
+	local BodyLength      = Data.ProjLength - CapLength
+	local FreeVol, FreeLength, FreeRadius = ACF.RoundShellCapacity(Data.PropMass, Data.ProjArea, Data.Caliber, BodyLength)
+	local Standoff        = (CapLength + FreeLength * ToolData.StandoffRatio) * 1e-2 -- cm to m
+	FreeVol               = FreeVol * (1 - ToolData.StandoffRatio)
+	FreeLength            = FreeLength * (1 - ToolData.StandoffRatio)
+	local ChargeDiameter  = 2 * FreeRadius
+	local MinConeAng      = math.deg(math.atan(FreeRadius / FreeLength))
+	local LinerAngle      = math.Clamp(ToolData.LinerAngle, MinConeAng, 90) -- Cone angle is angle between cone walls, not between a wall and the center line
+	local LinerMass, ConeVol, ConeLength = self:ConeCalc(LinerAngle, FreeRadius)
 
-	local LinerRad    = math.rad(LinerAngle * 0.5)
-	local SlugCaliber = Data.Caliber - Data.Caliber * (math.sin(LinerRad) * 0.5 + math.cos(LinerRad) * 1.5) * 0.5
-	local SlugArea    = math.pi * (SlugCaliber * 0.5) ^ 2
-	local ConeVol     = ConeArea * Data.Caliber * 0.02
+	-- Charge length increases jet velocity, but with diminishing returns. All explosive sorrounding the cone has 100% effectiveness,
+	--  but the explosive behind it sees it reduced. Most papers put the maximum useful head length (explosive length behind the
+	--  cone) at around 1.5-1.8 times the charge's diameter. Past that, adding more explosive won't do much.
+	local RearFillLen  = FreeLength - ConeLength  -- Length of explosive behind the liner
+	local Exponential  = math.exp(2 * RearFillLen / (ChargeDiameter * ACF.MaxChargeHeadLen))
+	local EquivFillLen = ChargeDiameter * ACF.MaxChargeHeadLen * ((Exponential - 1) / (Exponential + 1)) -- Equivalent length of explosive
+	local FrontFillVol = FreeVol * ConeLength / FreeLength - ConeVol -- Volume of explosive sorounding the liner
+	local RearFillVol  = FreeVol * RearFillLen / FreeLength -- Volume behind the liner
+	local EquivFillVol = FreeVol * EquivFillLen / FreeLength + FrontFillVol -- Equivalent total explosive volume
+	local FillerEnergy = EquivFillVol * ACF.OctolDensity * 1e3 * ACF.TNTPower * ACF.OctolEquivalent
+	local FillerVol    = FrontFillVol + RearFillVol
+	local FillerMass   = FillerVol * ACF.OctolDensity
 
-	GUIData.MaxConeAng = MaxConeAng
+	-- At lower cone angles, the explosive crushes the cone inward, expelling a jet. The steeper the cone, the faster the jet, but the less mass expelled
+	local MinVelMult = (0.98 - 0.6) * LinerAngle / 90 + 0.6
+	local JetMass    = LinerMass * ((1 - 0.8)* LinerAngle / 90  + 0.8)
+	local JetAvgVel  = (2 * FillerEnergy / JetMass) ^ 0.5  -- Average velocity of the copper jet
+	local JetMinVel  = JetAvgVel * MinVelMult              -- Minimum velocity of the jet (the rear)
+	-- Calculates the maximum velocity, considering the velocity distribution is linear from the rear to the tip (integrated this by hand, pain :) )
+	local JetMaxVel  = 0.5 * (3 ^ 0.5 * (8 * FillerEnergy - JetMass * JetMinVel ^ 2) ^ 0.5 / JetMass ^ 0.5 - JetMinVel) -- Maximum velocity of the jet (the tip)
+
+	-- Both the "magic numbers" are unitless, tuning constants that were used to fit the breakup time to real world values, I suggest they not be messed with
+	local BreakupTime    = 1.6e-6 * (5e9 * JetMass / (JetMaxVel - JetMinVel)) ^ 0.3333  -- Jet breakup time in seconds
+	local BreakupDist    = JetMaxVel * BreakupTime
+
+	GUIData.MinConeAng = MinConeAng
 
 	Data.ConeAng        = LinerAngle
-	Data.FillerMass     = FreeFillerVol * FillerRatio * ACF.HEDensity
-	Data.CasingMass		= (GUIData.ProjVolume - FreeVol) * ACF.SteelDensity
-	Data.ProjMass       = (math.max(FreeFillerVol * (1 - FillerRatio), 0) + ConeVol) * ACF.SteelDensity + Data.FillerMass + Data.CasingMass
-	Data.MuzzleVel      = ACF.MuzzleVelocity(Data.PropMass, Data.ProjMass, Data.Efficiency) * 1.25
-	Data.SlugMass       = ConeVol * ACF.SteelDensity
-	Data.SlugCaliber    = SlugCaliber
-	Data.SlugDragCoef   = SlugArea * 0.0001 / Data.SlugMass
-	Data.BoomFillerMass	= Data.FillerMass * ACF.HEATBoomConvert
-	Data.HEATFillerMass = Data.FillerMass * (1 - ACF.HEATBoomConvert)
-	Data.SlugMV			= self:CalcSlugMV(Data)
+	Data.MinConeAng     = MinConeAng
+	Data.FillerMass     = FillerMass
+	local NonCasingVol  = ACF.RoundShellCapacity(Data.PropMass, Data.ProjArea, Data.Caliber, Data.ProjLength)
+	Data.CasingMass		= (GUIData.ProjVolume - NonCasingVol) * ACF.SteelDensity
+	Data.ProjMass       = Data.FillerMass + Data.CasingMass + LinerMass
+	Data.MuzzleVel      = ACF.MuzzleVelocity(Data.PropMass, Data.ProjMass, Data.Efficiency)
+	Data.BoomFillerMass	= Data.FillerMass * ACF.HEATBoomConvert * ACF.OctolEquivalent -- In TNT equivalent
+	Data.LinerMass      = LinerMass
+	Data.JetMass        = JetMass
+	Data.JetMinVel      = JetMinVel
+	Data.JetMaxVel      = JetMaxVel
+	Data.BreakupTime    = BreakupTime
+	Data.Standoff       = Standoff
+	Data.BreakupDist    = BreakupDist
 	Data.DragCoef		= Data.ProjArea * 0.0001 / Data.ProjMass
 	Data.CartMass		= Data.PropMass + Data.ProjMass
 
@@ -57,5 +85,5 @@ if SERVER then
 		Entity:SetNW2String("AmmoType", "HEATFS")
 	end
 else
-	ACF.RegisterAmmoDecal("HEATFS", "damage/heat_pen", "damage/heat_rico", function(Caliber) return Caliber * 0.1667 end)
+
 end

--- a/lua/entities/acf_ammo/init.lua
+++ b/lua/entities/acf_ammo/init.lua
@@ -448,8 +448,8 @@ do -- ACF Activation and Damage -----------------
 		self.ACF.Type = "Prop"
 	end
 
-	function ENT:ACF_OnDamage(Bullet, Trace)
-		local HitRes = ACF.PropDamage(Bullet, Trace) --Calling the standard damage prop function
+	function ENT:ACF_OnDamage(Bullet, Trace, Volume)
+		local HitRes = ACF.PropDamage(Bullet, Trace, Volume) --Calling the standard damage prop function
 
 		if self.Exploding or not self.IsExplosive then return HitRes end
 

--- a/lua/entities/acf_armor/init.lua
+++ b/lua/entities/acf_armor/init.lua
@@ -171,13 +171,13 @@ do -- ACF Activation and Damage
 		self.ACF.Type      = "Prop"
 	end
 
-	function ENT:ACF_OnDamage(Bullet, Trace)
+	function ENT:ACF_OnDamage(Bullet, Trace, Volume)
 		local Entity = Trace.Entity
 		local Armor  = Entity:GetArmor(Trace)
 		local Area   = Bullet.ProjArea
 		local Pen    = Bullet:GetPenetration() -- RHA Penetration
 		local MaxPen = math.min(Armor, Pen)
-		local Damage = MaxPen * Area -- Damage is simply the volume of the hole made
+		local Damage = isnumber(Volume) and Volume or MaxPen * Area -- Damage is simply the volume of the hole made
 		local HP     = self.ACF.Health
 
 		self.ACF.Health = HP - Damage -- Update health

--- a/lua/entities/acf_engine/init.lua
+++ b/lua/entities/acf_engine/init.lua
@@ -569,8 +569,8 @@ function ENT:ACF_Activate()
 end
 
 --This function needs to return HitRes
-function ENT:ACF_OnDamage(Bullet, Trace)
-	local Res = ACF.PropDamage(Bullet, Trace)
+function ENT:ACF_OnDamage(Bullet, Trace, Volume)
+	local Res = ACF.PropDamage(Bullet, Trace, Volume)
 
 	--adjusting performance based on damage
 	local TorqueMult = math.Clamp(((1 - self.TorqueScale) / 0.5) * ((self.ACF.Health / self.ACF.MaxHealth) - 1) + 1, self.TorqueScale, 1)

--- a/lua/entities/acf_fueltank/init.lua
+++ b/lua/entities/acf_fueltank/init.lua
@@ -256,7 +256,7 @@ function ENT:ACF_Activate(Recalc)
 	end
 
 	local Armour = self.EmptyMass * 1000 / self.ACF.Area / 0.78 --So we get the equivalent thickness of that prop in mm if all it's weight was a steel plate
-	local Health = self.ACF.Volume / ACF.Threshold --Setting the threshold of the prop Area gone 
+	local Health = self.ACF.Volume / ACF.Threshold --Setting the threshold of the prop Area gone
 	local Percent = 1
 
 	if Recalc and self.ACF.Health and self.ACF.MaxHealth then
@@ -270,8 +270,8 @@ function ENT:ACF_Activate(Recalc)
 	self.ACF.Type = "Prop"
 end
 
-function ENT:ACF_OnDamage(Bullet, Trace)
-	local HitRes = ACF.PropDamage(Bullet, Trace) --Calling the standard damage prop function
+function ENT:ACF_OnDamage(Bullet, Trace, Volume)
+	local HitRes = ACF.PropDamage(Bullet, Trace, Volume) --Calling the standard damage prop function
 	local NoExplode = self.FuelType == "Diesel" and not (Type == "HE" or Type == "HEAT")
 
 	if self.Exploding or NoExplode or not self.IsExplosive then return HitRes end


### PR DESCRIPTION
Full HEAT rework! 
Removed "HEAT slugs" and added actual jet penetration closely modeling real world behavior.
Jets that penetrate explosive entities detonate them, great if you hit an ammo crate dead on.
Each penetration now produces spalling, which makes it's way towards ACF entities and the like.
Standoff is realistically modeled. Shells have customizable passive standoff.

A few disclaimers, as I had to touch parts of the code I'm not extraordinarily familiar with:
- I had to move the effects server-side due to the penetration being handled by the server exclusively
- The way HEAT projectiles handle impacts, detonation and damage is fairly non-standard, because the existing functions are very restrictive, and set up with basically just AP in mind. I had to get creative, not in a good way
- I did basic testing, but there's probably a lot of things missing, some bugs will most likely show up
- Balancing is not all there, but when I am motivated I'll play around with the values some more - it is not easy with how many variables there are. If anyone wants to do the same let me know and I'll explain the penetration and ammo update code (it is commented pretty in-depth regardless)

I'll post the accompanying PR to the missiles repository as usual