### PR TITLE
HEAT fixes, slight restat, and missile-related improvements

### DIFF
--- a/lua/acf/base/acf_globals.lua
+++ b/lua/acf/base/acf_globals.lua
@@ -78,7 +78,8 @@ do -- ACF global vars
 	ACF.CompBEquivalent    = 1.33    -- Relative to TNT
 	ACF.OctolDensity       = 1.83e-3 -- kg/cm^3
 	ACF.OctolEquivalent    = 1.54    -- Relative to TNT
-	ACF.LinerThicknessMult = 0.07    -- Metal liner thickness multiplier
+	ACF.HEATEfficiency     = 0.5     -- Efficiency of converting explosive energy to velocity
+	ACF.LinerThicknessMult = 0.03    -- Metal liner thickness multiplier
 	ACF.MaxChargeHeadLen   = 1.5     -- Maximum shaped charge head length (in charge diameters), lengths above will incur diminishing returns
 	ACF.HEATPenMul         = 1.1     -- Linear jet penetration multiplier
 	ACF.HEATMinPenVel      = 1000    -- m/s, minimum velocity of the copper jet that contributes to penetration

--- a/lua/acf/shared/ammo_types/heatfs.lua
+++ b/lua/acf/shared/ammo_types/heatfs.lua
@@ -19,25 +19,25 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 	local BodyLength      = Data.ProjLength - CapLength
 	local FreeVol, FreeLength, FreeRadius = ACF.RoundShellCapacity(Data.PropMass, Data.ProjArea, Data.Caliber, BodyLength)
 	local Standoff        = (CapLength + FreeLength * ToolData.StandoffRatio) * 1e-2 -- cm to m
-	FreeVol               = FreeVol * (1 - ToolData.StandoffRatio)
-	FreeLength            = FreeLength * (1 - ToolData.StandoffRatio)
-	local ChargeDiameter  = 2 * FreeRadius
-	local MinConeAng      = math.deg(math.atan(FreeRadius / FreeLength))
+	local WarheadVol      = FreeVol * (1 - ToolData.StandoffRatio)
+	local WarheadLength   = FreeLength * (1 - ToolData.StandoffRatio)
+	local WarheadDiameter = 2 * FreeRadius
+	local MinConeAng      = math.deg(math.atan(FreeRadius / WarheadLength))
 	local LinerAngle      = math.Clamp(ToolData.LinerAngle, MinConeAng, 90) -- Cone angle is angle between cone walls, not between a wall and the center line
 	local LinerMass, ConeVol, ConeLength = self:ConeCalc(LinerAngle, FreeRadius)
 
 	-- Charge length increases jet velocity, but with diminishing returns. All explosive sorrounding the cone has 100% effectiveness,
 	--  but the explosive behind it sees it reduced. Most papers put the maximum useful head length (explosive length behind the
 	--  cone) at around 1.5-1.8 times the charge's diameter. Past that, adding more explosive won't do much.
-	local RearFillLen  = FreeLength - ConeLength  -- Length of explosive behind the liner
-	local Exponential  = math.exp(2 * RearFillLen / (ChargeDiameter * ACF.MaxChargeHeadLen))
-	local EquivFillLen = ChargeDiameter * ACF.MaxChargeHeadLen * ((Exponential - 1) / (Exponential + 1)) -- Equivalent length of explosive
-	local FrontFillVol = FreeVol * ConeLength / FreeLength - ConeVol -- Volume of explosive sorounding the liner
-	local RearFillVol  = FreeVol * RearFillLen / FreeLength -- Volume behind the liner
-	local EquivFillVol = FreeVol * EquivFillLen / FreeLength + FrontFillVol -- Equivalent total explosive volume
+	local RearFillLen  = WarheadLength - ConeLength  -- Length of explosive behind the liner
+	local Exponential  = math.exp(2 * RearFillLen / (WarheadDiameter * ACF.MaxChargeHeadLen))
+	local EquivFillLen = WarheadDiameter * ACF.MaxChargeHeadLen * ((Exponential - 1) / (Exponential + 1)) -- Equivalent length of explosive
+	local FrontFillVol = WarheadVol * ConeLength / WarheadLength - ConeVol -- Volume of explosive sorounding the liner
+	local RearFillVol  = WarheadVol * RearFillLen / WarheadLength -- Volume behind the liner
+	local EquivFillVol = WarheadVol * EquivFillLen / WarheadLength + FrontFillVol -- Equivalent total explosive volume
 	local LengthPct    = Data.ProjLength / (Data.MaxProjLength or Data.ProjLength * 2)
-	local OverEnergy   = math.min(math.Remap(LengthPct, 0.6, 1, 1, 0.3), 1)
-	local FillerEnergy = OverEnergy * EquivFillVol * ACF.CompBDensity * 1e3 * ACF.TNTPower * ACF.CompBEquivalent
+	local OverEnergy   = math.min(math.Remap(LengthPct, 0.6, 1, 1, 0.3), 1) -- Excess explosive power makes the jet lose velocity
+	local FillerEnergy = OverEnergy * EquivFillVol * ACF.OctolDensity * 1e3 * ACF.TNTPower * ACF.OctolEquivalent * ACF.HEATEfficiency
 	local FillerVol    = FrontFillVol + RearFillVol
 	local FillerMass   = FillerVol * ACF.OctolDensity
 
@@ -74,6 +74,10 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 	Data.CartMass		= Data.PropMass + Data.ProjMass
 
 	hook.Run("ACF_UpdateRoundData", self, ToolData, Data, GUIData)
+
+	if Data.MissileStandoff then
+		Data.Standoff = (FreeLength * ToolData.StandoffRatio + Data.MissileStandoff) * 1e-2
+	end
 
 	for K, V in pairs(self:GetDisplayData(Data)) do
 		GUIData[K] = V


### PR DESCRIPTION
Changes HEAT-FS' explosive to octol (which I had forgotten to do), reduces the liner mass to more realistic values, and lays the groundwork to allow missiles to set penetration multipliers and custom standoff