### PR TITLE
Wire descriptions

### DIFF
--- a/lua/acf/shared/gearboxes/3-auto.lua
+++ b/lua/acf/shared/gearboxes/3-auto.lua
@@ -97,8 +97,8 @@ ACF.RegisterGearboxClass("3-Auto", {
 	SetupInputs = function(List)
 		local Count = #List
 
-		List[Count + 1] = "Hold Gear"
-		List[Count + 2] = "Shift Speed Scale"
+		List[Count + 1] = "Hold Gear (Prevents the automatic shifting from occurring)"
+		List[Count + 2] = "Shift Speed Scale (Scales the speeds set for the automatic shifting)"
 	end,
 	OnLast = function(Gearbox)
 		Gearbox.Automatic  = nil

--- a/lua/acf/shared/gearboxes/5-auto.lua
+++ b/lua/acf/shared/gearboxes/5-auto.lua
@@ -96,8 +96,8 @@ ACF.RegisterGearboxClass("5-Auto", {
 	SetupInputs = function(List)
 		local Count = #List
 
-		List[Count + 1] = "Hold Gear"
-		List[Count + 2] = "Shift Speed Scale"
+		List[Count + 1] = "Hold Gear (Prevents the automatic shifting from occurring)"
+		List[Count + 2] = "Shift Speed Scale (Scales the speeds set for the automatic shifting)"
 	end,
 	OnLast = function(Gearbox)
 		Gearbox.Automatic  = nil

--- a/lua/acf/shared/gearboxes/7-auto.lua
+++ b/lua/acf/shared/gearboxes/7-auto.lua
@@ -96,8 +96,8 @@ ACF.RegisterGearboxClass("7-Auto", {
 	SetupInputs = function(List)
 		local Count = #List
 
-		List[Count + 1] = "Hold Gear"
-		List[Count + 2] = "Shift Speed Scale"
+		List[Count + 1] = "Hold Gear (Prevents the automatic shifting from occurring)"
+		List[Count + 2] = "Shift Speed Scale (Scales the speeds set for the automatic shifting)"
 	end,
 	OnLast = function(Gearbox)
 		Gearbox.Automatic  = nil

--- a/lua/acf/shared/gearboxes/cvt.lua
+++ b/lua/acf/shared/gearboxes/cvt.lua
@@ -50,13 +50,13 @@ ACF.RegisterGearboxClass("CVT", {
 		Data.MaxRPM = math.Clamp(Max, Data.MinRPM + 100, 10000)
 	end,
 	SetupInputs = function(List)
-		List[#List + 1] = "CVT Ratio"
+		List[#List + 1] = "CVT Ratio (Manually sets this specific gear ratio in the CVT)"
 	end,
 	SetupOutputs = function(List)
 		local Count = #List
 
-		List[Count + 1] = "Min Target RPM"
-		List[Count + 2] = "Max Target RPM"
+		List[Count + 1] = "Min Target RPM (The lower targeted RPM for the CVT to maintain)"
+		List[Count + 2] = "Max Target RPM (The upper targeted RPM for the CVT to maintain)"
 	end,
 	OnLast = function(Gearbox)
 		Gearbox.CVT      = nil

--- a/lua/acf/shared/gearboxes/doublediff.lua
+++ b/lua/acf/shared/gearboxes/doublediff.lua
@@ -1,4 +1,4 @@
--- Double Differential 
+-- Double Differential
 -- Weight
 local GearDDSW = 45
 local GearDDMW = 85
@@ -25,7 +25,7 @@ ACF.RegisterGearboxClass("DoubleDiff", {
 	OnSpawn = InitGearbox,
 	OnUpdate = InitGearbox,
 	SetupInputs = function(List)
-		List[#List + 1] = "Steer Rate"
+		List[#List + 1] = "Steer Rate (A -1 to 0 to -1 steering rate for apply power to each side individually)"
 	end,
 	OnLast = function(Gearbox)
 		Gearbox.DoubleDiff = nil

--- a/lua/entities/acf_ammo/init.lua
+++ b/lua/entities/acf_ammo/init.lua
@@ -272,8 +272,8 @@ do -- Spawning and Updating --------------------
 		Crate.Owner       = Player -- MUST be stored on ent for PP
 		Crate.IsExplosive = true
 		Crate.Weapons     = {}
-		Crate.Inputs      = WireLib.CreateInputs(Crate, { "Load" })
-		Crate.Outputs     = WireLib.CreateOutputs(Crate, { "Entity [ENTITY]", "Ammo", "Loading" })
+		Crate.Inputs      = WireLib.CreateInputs(Crate, { "Load (If true, will allow rounds to load from this crate)" })
+		Crate.Outputs     = WireLib.CreateOutputs(Crate, { "Entity (This ammo crate) [ENTITY]", "Ammo (Rounds left in the crate)", "Loading (Whether or not rounds can load from this crate)" })
 		Crate.DataStore	  = ACF.GetEntityArguments("acf_ammo")
 
 		WireLib.TriggerOutput(Crate, "Entity", Crate)

--- a/lua/entities/acf_engine/init.lua
+++ b/lua/entities/acf_engine/init.lua
@@ -354,8 +354,15 @@ do -- Spawn and Update functions
 		Engine.Throttle     = 0
 		Engine.FlyRPM       = 0
 		Engine.SoundPath    = EngineData.Sound
-		Engine.Inputs       = WireLib.CreateInputs(Engine, { "Active", "Throttle" })
-		Engine.Outputs      = WireLib.CreateOutputs(Engine, { "RPM", "Torque", "Power", "Fuel Use", "Entity [ENTITY]", "Mass", "Physical Mass" })
+		Engine.Inputs       = WireLib.CreateInputs(Engine, { "Active (Turns the engine on if it is not 0)", "Throttle (0-100 for how hard the engine should run)" })
+		Engine.Outputs      = WireLib.CreateOutputs(Engine, {
+			"RPM (Current rotations per minute of the engine)",
+			"Torque (nM of torque from the engine)",
+			"Power (kW of power from the engine)",
+			"Fuel Use (Amount of fuel being used)",
+			"Entity (The engine itself) [ENTITY]",
+			"Mass (Total mass detected on the vehicle by the engine)",
+			"Physical Mass (Physical mass detected on the vehicle by the engine)" })
 		Engine.DataStore    = ACF.GetEntityArguments("acf_engine")
 
 		WireLib.TriggerOutput(Engine, "Entity", Engine)

--- a/lua/entities/acf_fueltank/init.lua
+++ b/lua/entities/acf_fueltank/init.lua
@@ -141,8 +141,13 @@ do -- Spawn and Update functions
 		Tank.Engines	= {}
 		Tank.Leaking	= 0
 		Tank.LastThink	= 0
-		Tank.Inputs		= WireLib.CreateInputs(Tank, { "Active", "Refuel Duty" })
-		Tank.Outputs	= WireLib.CreateOutputs(Tank, { "Activated", "Fuel", "Capacity", "Leaking", "Entity [ENTITY]" })
+		Tank.Inputs		= WireLib.CreateInputs(Tank, { "Active (Whether or not fuel can be drawn from this tank)", "Refuel Duty (If 1, sends fuel to other tanks with matching types)" })
+		Tank.Outputs	= WireLib.CreateOutputs(Tank, {
+			"Activated (Whether or not this tank is active)",
+			"Fuel (Amount of fuel currently in the tank, in liters/kWh)",
+			"Capacity (Total amount of fuel the tank can hold, in liters/kWh)",
+			"Leaking (If 1, the tank is losing fuel)",
+			"Entity (The fuel tank itself) [ENTITY]" })
 		Tank.DataStore	= ACF.GetEntityArguments("acf_fueltank")
 
 		WireLib.TriggerOutput(Tank, "Entity", Tank)

--- a/lua/entities/acf_gearbox/init.lua
+++ b/lua/entities/acf_gearbox/init.lua
@@ -286,7 +286,7 @@ do -- Spawn and Update functions
 	end
 
 	local function CreateInputs(Entity, Data, Class, Gearbox)
-		local List = { "Gear", "Gear Up", "Gear Down" }
+		local List = { "Gear (Sets the gear to this number)", "Gear Up (Shifts the gearbox up)", "Gear Down (Shifts the gearbox down)" }
 
 		if Class.SetupInputs then
 			Class.SetupInputs(List, Entity, Data, Class, Gearbox)
@@ -302,7 +302,7 @@ do -- Spawn and Update functions
 	end
 
 	local function CreateOutputs(Entity, Data, Class, Gearbox)
-		local List = { "Current Gear", "Ratio", "Entity [ENTITY]" }
+		local List = { "Current Gear (The gear that is currently active)", "Ratio (The final ratio of the current gear arrangement)", "Entity (The gearbox itself) [ENTITY]" }
 
 		if Class.SetupOutputs then
 			Class.SetupOutputs(List, Entity, Data, Class, Gearbox)
@@ -390,13 +390,13 @@ do -- Spawn and Update functions
 		local Count = #List
 
 		if Entity.DualClutch then
-			List[Count + 1] = "Left Clutch"
-			List[Count + 2] = "Right Clutch"
-			List[Count + 3] = "Left Brake"
-			List[Count + 4] = "Right Brake"
+			List[Count + 1] = "Left Clutch (The amount of power allowed through the left side, inversely)"
+			List[Count + 2] = "Right Clutch (The amount of power allowed through the right side, inversely)"
+			List[Count + 3] = "Left Brake (The amount of braking to apply to the left side)"
+			List[Count + 4] = "Right Brake (The amount of braking to apply to the right side)"
 		else
-			List[Count + 1] = "Clutch"
-			List[Count + 2] = "Brake"
+			List[Count + 1] = "Clutch (The amount of power to allow through the gearbox, inversely)"
+			List[Count + 2] = "Brake (The amount of braking to apply to any wheels attached)"
 		end
 	end)
 	hook.Add("ACF_OnEntityLast", "ACF Cleanup Gearbox Data", function(Class, Gearbox)

--- a/lua/entities/acf_gun/init.lua
+++ b/lua/entities/acf_gun/init.lua
@@ -68,7 +68,7 @@ do -- Spawn and Update functions --------------------------------
 	end
 
 	local function CreateInputs(Entity, Data, Class, Weapon)
-		local List = { "Fire", "Unload", "Reload" }
+		local List = { "Fire (Fires the weapon)", "Unload (Empties the breech/magazine)", "Reload (Forces the weapon to reload)" }
 
 		if Class.SetupInputs then
 			Class.SetupInputs(List, Entity, Data, Class, Weapon)
@@ -84,7 +84,16 @@ do -- Spawn and Update functions --------------------------------
 	end
 
 	local function CreateOutputs(Entity, Data, Class, Weapon)
-		local List = { "Ready", "Status [STRING]", "Total Ammo", "Entity [ENTITY]", "Shots Left", "Rate of Fire", "Reload Time", "Projectile Mass", "Muzzle Velocity" }
+		local List = {
+			"Ready (Whether the weapon can fire or not)",
+			"Status (Current state of the weapon) [STRING]",
+			"Total Ammo (Rounds immediately available to the weapon)",
+			"Entity (The weapon itself) [ENTITY]",
+			"Shots Left (How many rounds are left before a reload is required)",
+			"Rate of Fire (How fast the weapon can fire)",
+			"Reload Time (How long a reload will take)",
+			"Projectile Mass (The mass of the projectile)",
+			"Muzzle Velocity (The speed of the projectile, leaving the barrel)" }
 
 		if Class.SetupOutputs then
 			Class.SetupOutputs(List, Entity, Data, Class, Weapon)
@@ -198,7 +207,7 @@ do -- Spawn and Update functions --------------------------------
 		if Class ~= "acf_gun" then return end
 		if Entity.Caliber <= ACF.MinFuzeCaliber then return end
 
-		List[#List + 1] = "Fuze"
+		List[#List + 1] = "Fuze (The time, in seconds, before force detonating any fuze in the round)"
 	end)
 
 	-------------------------------------------------------------------------------
@@ -628,7 +637,7 @@ do -- Metamethods --------------------------------
 						if self:CanFire() then self:Shoot() end
 					end
 				end)
-			else -- No available crate to pull ammo from, out of ammo!				
+			else -- No available crate to pull ammo from, out of ammo!
 				self:SetState("Empty")
 
 				self.CurrentShot = 0

--- a/lua/entities/acf_piledriver/init.lua
+++ b/lua/entities/acf_piledriver/init.lua
@@ -48,7 +48,7 @@ do -- Spawning and Updating --------------------
 	end
 
 	local function CreateInputs(Entity, Data, Class)
-		local List = { "Fire" }
+		local List = { "Fire (Fires the piledriver)" }
 
 		if Class.SetupInputs then
 			Class.SetupInputs(List, Entity, Data, Class)
@@ -64,7 +64,15 @@ do -- Spawning and Updating --------------------
 	end
 
 	local function CreateOutputs(Entity, Data, Class)
-		local List = { "Ready", "Status [STRING]", "Shots Left", "Reload Time", "Rate of Fire", "Spike Mass", "Muzzle Velocity", "Entity [ENTITY]" }
+		local List = {
+			"Ready (If the piledriver can fire)",
+			"Status (Current state of the weapon) [STRING]",
+			"Shots Left (Amount of charges stored in the piledriver)",
+			"Reload Time (Charge rate)",
+			"Rate of Fire (How fast the piledriver can fire)",
+			"Spike Mass (Mass of the spike shot by the piledriver)",
+			"Muzzle Velocity (Speed of the spike shot by the piledriver)",
+			"Entity (The piledriver itself) [ENTITY]" }
 
 		if Class.SetupOutputs then
 			Class.SetupOutputs(List, Entity, Data, Class)


### PR DESCRIPTION
Using a recent addition (fix?) in wiremod, wire inputs/outputs can have descriptions tacked onto them which show up when you are using the wire tool. This goes over all of the entities in ACF-3 (not ACF-Missiles, yet) and adds descriptions to all of the wires.
Should partially close https://github.com/Stooberton/ACF-3/issues/216. Still need to do the same to ACF-Missiles however