### PR TITLE
ACF_GetHitAngle

### DIFF
--- a/lua/acf/base/util/sh_util.lua
+++ b/lua/acf/base/util/sh_util.lua
@@ -204,14 +204,16 @@ function ACF.RandomVector(Min, Max)
 	return Vector(X, Y, Z)
 end
 
-function ACF_GetHitAngle(HitNormal, HitVector)
-	local Ang = math.deg(math.acos(HitNormal:Dot(-HitVector:GetNormalized()))) -- Can output nan sometimes on extremely small angles
+function ACF.GetReflect(HitNormal,BulletDirection)
+	return BulletDirection - 2 * (HitNormal:Dot(BulletDirection) * HitNormal)
+end
 
-	if Ang ~= Ang then -- nan is the only value that does not equal itself
-		return 0 -- return 0 instead of nan
-	else
-		return Ang
-	end
+function ACF.GetHitAngle(HitNormal, HitDir)
+	local FV = HitDir:GetNormalized()
+	local Ang = math.deg(math.acos(FV:Dot(-ACF.GetReflect(HitNormal,FV))))
+
+	if Ang ~= Ang then print("invalid angle in ACF.GetHitAngle\n",">HitNormal: " .. tostring(HitNormal) .. ", HitDir (BulletVel): " .. tostring(HitDir)) return 0 end
+	return Ang / 2
 end
 
 do -- Native type verification functions

--- a/lua/acf/server/ballistics.lua
+++ b/lua/acf/server/ballistics.lua
@@ -319,7 +319,7 @@ do -- Terminal ballistics --------------------------
 	end
 
 	function ACF_CalcRicochet(Bullet, Trace)
-		local HitAngle = ACF_GetHitAngle(Trace.HitNormal, Bullet.Flight)
+		local HitAngle = ACF.GetHitAngle(Trace.HitNormal, Bullet.Flight)
 		-- Ricochet distribution center
 		local sigmoidCenter = Bullet.DetonatorAngle or (Bullet.Ricochet - math.abs(Bullet.Speed / 39.37 - Bullet.LimitVel) / 100)
 
@@ -375,7 +375,7 @@ do -- Terminal ballistics --------------------------
 	end
 
 	function ACF_Ricochet(Bullet, Trace)
-		local HitAngle = ACF_GetHitAngle(Trace.HitNormal, Bullet.Flight)
+		local HitAngle = ACF.GetHitAngle(Trace.HitNormal, Bullet.Flight)
 		local Speed    = Bullet.Flight:Length() / ACF.Scale
 		local MinAngle = math.min(Bullet.Ricochet - Speed / 39.37 / 30 + 20,89.9) -- Making the chance of a ricochet get higher as the speeds increase
 		local Ricochet = 0

--- a/lua/acf/server/damage.lua
+++ b/lua/acf/server/damage.lua
@@ -354,8 +354,7 @@ do -- Deal Damage ---------------------------
 	local TimerCreate = timer.Create
 
 	local function CalcDamage(Bullet, Trace, Volume)
-		-- TODO: Why are we getting impact angles outside these bounds?
-		local Angle   = math.Clamp(ACF_GetHitAngle(Trace.HitNormal, Bullet.Flight), -90, 90)
+		local Angle   = ACF.GetHitAngle(Trace.HitNormal, Bullet.Flight)
 		local Area    = Bullet.ProjArea
 		local HitRes  = {}
 

--- a/lua/acf/shared/ammo_types/heat.lua
+++ b/lua/acf/shared/ammo_types/heat.lua
@@ -283,7 +283,7 @@ if SERVER then
 				Damage = 0
 			end
 			local SlopeFactor    = BaseArmor / Caliber
-			local Angle          = math.Clamp(ACF_GetHitAngle(TraceRes.HitNormal, Direction), -90, 90)
+			local Angle          = ACF.GetHitAngle(TraceRes.HitNormal, Direction)
 			local EffectiveArmor = Ent.GetArmor and BaseArmor or BaseArmor / math.abs(math.cos(math.rad(Angle)) ^ SlopeFactor)
 
 			-- Percentage of total jet mass lost to this penetration

--- a/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
@@ -273,7 +273,7 @@ e2function number ranger:acfEffectiveArmor()
 	if not ACF.Check(this.Entity) then return 0 end
 
 	local Armor    = this.Entity.ACF.Armour
-	local HitAngle = ACF_GetHitAngle(this.HitNormal , this.HitPos - this.StartPos)
+	local HitAngle = ACF.GetHitAngle(this.HitNormal , this.HitPos - this.StartPos)
 
 	return Round(Armor / math.abs(math.cos(math.rad(HitAngle))), 2)
 end

--- a/lua/weapons/gmod_tool/stools/acfarmorprop.lua
+++ b/lua/weapons/gmod_tool/stools/acfarmorprop.lua
@@ -160,7 +160,7 @@ if CLIENT then
 		if Ent.GetArmor then -- Is procedural armor
 			local Material = Ent.ArmorType
 			local Mass     = math.Round(Weapon:GetNWFloat("WeightMass", 0), 1)
-			local Angle    = math.Round(ACF_GetHitAngle(Trace.HitNormal, (Trace.HitPos - Trace.StartPos):GetNormalized()), 1)
+			local Angle    = math.Round(ACF.GetHitAngle(Trace.HitNormal, (Trace.HitPos - Trace.StartPos):GetNormalized()), 1)
 			local Armor    = math.Round(Ent:GetArmor(Trace))
 			local Size     = Ent:GetSize()
 			local Nominal  = math.Round(math.min(Size[1], Size[2], Size[3]) * 25.4, 1)


### PR DESCRIPTION
A speculative fix for ACF_GetHitAngle, the core of the issue returning nan can't really be fully fixed due to decimal accuracy errors, however we can check when it errors. Also moves the relevant functions to the namespace, and gets rid of clamps.
For some reason the old function seemed to randomly give values way outside of its range, this new function now actually checks for the ricochet vector and then compares angles between the two, outputting half of the angle found for compatibility sake.

Shooouuuld fix https://github.com/Stooberton/ACF-3/issues/177, I can't recreate it any more at least.
As for outputting nan, it only really happened when unrealistic values got passed to the function, or in really rare cases, certain velocities that don't go near the HitNormal's direction in any way.