### PR TITLE
Adjust tickrate for engines

### DIFF
--- a/lua/acf/base/acf_globals.lua
+++ b/lua/acf/base/acf_globals.lua
@@ -24,6 +24,7 @@ do -- ACF global vars
 	ACF.WorkshopExtras     = false -- Enable extra workshop content download for clients
 	ACF.SmokeWind          = 5 + math.random() * 35 --affects the ability of smoke to be used for screening effect
 	ACF.LinkDistance       = 650 -- Maximum distance, on inches, at which components will remain linked with each other
+	ACF.TickRate		   = 1 / 66 -- 66 tick for everyone?
 
 	ACF.GunsCanFire        = true
 	ACF.GunsCanSmoke       = true

--- a/lua/entities/acf_engine/init.lua
+++ b/lua/entities/acf_engine/init.lua
@@ -195,7 +195,7 @@ local function SetActive(Entity, Value)
 			Entity.Sound:PlayEx(Volume, Pitch)
 		end
 
-		TimerSimple(engine.TickInterval(), function()
+		TimerSimple(ACF.TickRate, function()
 			if not IsValid(Entity) then return end
 
 			Entity:CalcRPM()
@@ -697,7 +697,7 @@ function ENT:CalcRPM()
 
 	self:UpdateOutputs()
 
-	TimerSimple(engine.TickInterval(), function()
+	TimerSimple(ACF.TickRate, function()
 		if not IsValid(self) then return end
 
 		self:CalcRPM()


### PR DESCRIPTION
Moves engine RPM calculation to a fixed tickrate, this should fix the performance variation between servers.
Should close https://github.com/Stooberton/ACF-3/issues/136.