### PR TITLE
Add PreEntitySpawn hook

### DIFF
--- a/lua/entities/acf_ammo/init.lua
+++ b/lua/entities/acf_ammo/init.lua
@@ -256,6 +256,9 @@ do -- Spawning and Updating --------------------
 		local Ammo   = AmmoTypes[Data.AmmoType]()
 		local Model  = "models/holograms/rcube_thin.mdl"
 
+		local CanSpawn = HookRun("ACF_PreEntitySpawn", "acf_ammo", Player, Data, Class, Weapon, Ammo)
+		if CanSpawn == false then return false end
+
 		Player:AddCleanup("acf_ammo", Crate)
 		Player:AddCount("_acf_ammo", Crate)
 

--- a/lua/entities/acf_armor/init.lua
+++ b/lua/entities/acf_armor/init.lua
@@ -72,6 +72,9 @@ do -- Spawning and Updating
 
 		local Armor = Armors[Data.ArmorType]
 
+		local CanSpawn = hook.Run("ACF_PreEntitySpawn", "acf_armor", Player, Data, Armor)
+		if CanSpawn == false then return false end
+
 		Player:AddCount("_acf_armor", Plate)
 		Player:AddCleanup("_acf_armor", Plate)
 

--- a/lua/entities/acf_engine/init.lua
+++ b/lua/entities/acf_engine/init.lua
@@ -332,6 +332,9 @@ do -- Spawn and Update functions
 
 		if not Player:CheckLimit(Limit) then return false end
 
+		local CanSpawn = HookRun("ACF_OnEntitySpawn", "acf_engine", Player, Data, Class, EngineData)
+		if CanSpawn == false then return false end
+
 		local Engine = ents.Create("acf_engine")
 
 		if not IsValid(Engine) then return end

--- a/lua/entities/acf_engine/init.lua
+++ b/lua/entities/acf_engine/init.lua
@@ -332,7 +332,7 @@ do -- Spawn and Update functions
 
 		if not Player:CheckLimit(Limit) then return false end
 
-		local CanSpawn = HookRun("ACF_OnEntitySpawn", "acf_engine", Player, Data, Class, EngineData)
+		local CanSpawn = HookRun("ACF_PreEntitySpawn", "acf_engine", Player, Data, Class, EngineData)
 		if CanSpawn == false then return false end
 
 		local Engine = ents.Create("acf_engine")

--- a/lua/entities/acf_fueltank/init.lua
+++ b/lua/entities/acf_fueltank/init.lua
@@ -125,6 +125,9 @@ do -- Spawn and Update functions
 
 		if not Player:CheckLimit(Limit) then return end
 
+		local CanSpawn = HookRun("ACF_PreEntitySpawn", "acf_fueltank", Player, Data, Class, FuelTank)
+		if CanSpawn == false then return end
+
 		local Tank = ents.Create("acf_fueltank")
 
 		if not IsValid(Tank) then return end

--- a/lua/entities/acf_gearbox/init.lua
+++ b/lua/entities/acf_gearbox/init.lua
@@ -416,6 +416,9 @@ do -- Spawn and Update functions
 
 		if not Player:CheckLimit(Limit) then return end
 
+		local CanSpawn = HookRun("ACF_PreEntitySpawn", "acf_gearbox", Player, Data, Class, GearboxData)
+		if CanSpawn == false then return false end
+
 		local Gearbox = ents.Create("acf_gearbox")
 
 		if not IsValid(Gearbox) then return end

--- a/lua/entities/acf_gun/init.lua
+++ b/lua/entities/acf_gun/init.lua
@@ -220,11 +220,14 @@ do -- Spawn and Update functions --------------------------------
 
 		if not Player:CheckLimit(Limit) then return false end -- Check gun spawn limits
 
+		local Weapon = Class.Lookup[Data.Weapon]
+		local CanSpawn = HookRun("ACF_PreEntitySpawn", "acf_gun", Player, Data, Class, Weapon)
+
+		if CanSpawn == false then return false end
+
 		local Entity = ents.Create("acf_gun")
 
 		if not IsValid(Entity) then return end
-
-		local Weapon = Class.Lookup[Data.Weapon]
 
 		Player:AddCleanup(Class.Cleanup, Entity)
 		Player:AddCount(Limit, Entity)


### PR DESCRIPTION
I found a few situations where it would be nice to know when someone is _about_ to spawn an ACF entity, but after all of the built-in checks have passed.

I think this'll do the trick