### PR TITLE
Add PreUpdate hooks

### DIFF
--- a/lua/entities/acf_ammo/init.lua
+++ b/lua/entities/acf_ammo/init.lua
@@ -344,6 +344,9 @@ do -- Spawning and Updating --------------------
 		local Blacklist  = Ammo.Blacklist
 		local Extra      = ""
 
+		local CanUpdate, Reason = HookRun("ACF_PreEntityUpdate", "acf_ammo", self, Data, Class, Weapon, Ammo)
+		if CanUpdate == false then return CanUpdate, Reason end
+
 		if OldClass.OnLast then
 			OldClass.OnLast(self, OldClass)
 		end

--- a/lua/entities/acf_engine/init.lua
+++ b/lua/entities/acf_engine/init.lua
@@ -409,6 +409,9 @@ do -- Spawn and Update functions
 		local OldClass   = self.ClassData
 		local Feedback   = ""
 
+		local CanUpdate, Reason = HookRun("ACF_PreEntityUpdate", "acf_engine", self, Data, Class, EngineData)
+		if CanUpdate == false then return CanUpdate, Reason end
+
 		if OldClass.OnLast then
 			OldClass.OnLast(self, OldClass)
 		end

--- a/lua/entities/acf_fueltank/init.lua
+++ b/lua/entities/acf_fueltank/init.lua
@@ -196,6 +196,9 @@ do -- Spawn and Update functions
 		local OldClass = self.ClassData
 		local Feedback = ""
 
+		local CanUpdate, Reason = HookRun("ACF_PreEntityUpdate", "acf_fueltank", self, Data, Class, FuelTank)
+		if CanUpdate == false then return CanUpdate, Reason end
+
 		if OldClass.OnLast then
 			OldClass.OnLast(self, OldClass)
 		end

--- a/lua/entities/acf_gearbox/init.lua
+++ b/lua/entities/acf_gearbox/init.lua
@@ -500,6 +500,9 @@ do -- Spawn and Update functions
 		local OldClass    = self.ClassData
 		local Feedback     = ""
 
+		local CanUpdate, Reason = HookRun("ACF_PreEntityUpdate", "acf_gearbox", self, Data, Class, GearboxData)
+		if CanUpdate == false then return CanUpdate, Reason end
+
 		if OldClass.OnLast then
 			OldClass.OnLast(self, OldClass)
 		end

--- a/lua/entities/acf_gun/init.lua
+++ b/lua/entities/acf_gun/init.lua
@@ -296,6 +296,9 @@ do -- Spawn and Update functions --------------------------------
 		local Weapon   = Class.Lookup[Data.Weapon]
 		local OldClass = self.ClassData
 
+		local CanUpdate, Reason = HookRun("ACF_PreEntityUpdate", "acf_gun", self, Data, Class, Weapon)
+		if CanUpdate == false then return CanUpdate, Reason end
+
 		if self.State ~= "Empty" then
 			self:Unload()
 		end

--- a/lua/entities/acf_piledriver/init.lua
+++ b/lua/entities/acf_piledriver/init.lua
@@ -239,6 +239,9 @@ do -- Spawning and Updating --------------------
 		local Class    = Piledrivers[Data.Weapon]
 		local OldClass = self.ClassData
 
+		local CanUpdate, Reason = hook.Run("ACF_PreEntityUpdate", "acf_piledriver", self, Data, Class)
+		if CanUpdate == false then return CanUpdate, Reason end
+
 		if OldClass.OnLast then
 			OldClass.OnLast(self, OldClass)
 		end


### PR DESCRIPTION
A followup to my previous PR: https://github.com/Stooberton/ACF-3/pull/233

We also found a need to prevent players from updating their ACF entities.

I saw some code already existed for pre-update, but it wasn't in the places I needed it. I decided to add these in the same way I added the PreCreate. Let me know if you can think of a better way.

Thanks!