### PR TITLE
Fixed brake spazz, slightly more realistic performance

### DIFF
--- a/lua/acf/base/acf_globals.lua
+++ b/lua/acf/base/acf_globals.lua
@@ -29,6 +29,7 @@ do -- ACF global vars
 	ACF.MinimumArmor       = 1 -- Minimum possible armor that can be given to an entity
 	ACF.MaximumArmor       = 5000 -- Maximum possible armor that can be given to an entity
 	ACF.KillIconColor      = Color(200, 200, 48)
+	ACF.BrakeTorque        = 50000
 
 	ACF.GunsCanFire        = true
 	ACF.GunsCanSmoke       = true

--- a/lua/entities/acf_gearbox/init.lua
+++ b/lua/entities/acf_gearbox/init.lua
@@ -881,7 +881,6 @@ do -- Braking ------------------------------------------
 		local TorqueAxis = Phys:LocalToWorldVector(Link.Axis)
 		-- Wheel inertia as seen by the torque axis
 		local AxisInertia = Phys:LocalToWorldVector(Phys:GetInertia()):Dot(TorqueAxis)
-		local Velocity = Phys:GetVelocity():Length()
 		local BrakeMult = sign(Link.Vel) * ACF.BrakeTorque * Brake
 
 		local MaxBrake = math.abs(Link.Vel * 100 * AxisInertia * DeltaTime)

--- a/lua/entities/acf_gearbox/init.lua
+++ b/lua/entities/acf_gearbox/init.lua
@@ -869,21 +869,23 @@ do -- Movement -----------------------------------------
 end ----------------------------------------------------
 
 do -- Braking ------------------------------------------
+	local function sign(number)
+		return number > 0 and 1 or (number == 0 and 0 or -1)
+	end
+
 	local function BrakeWheel(Link, Wheel, Brake, DeltaTime)
 		local Phys = Wheel:GetPhysicsObject()
 
 		if not Phys:IsMotionEnabled() then return end -- skipping entirely if its frozen
 
 		local TorqueAxis = Phys:LocalToWorldVector(Link.Axis)
+		-- Wheel inertia as seen by the torque axis
+		local AxisInertia = Phys:LocalToWorldVector(Phys:GetInertia()):Dot(TorqueAxis)
 		local Velocity = Phys:GetVelocity():Length()
-		local BrakeMult = Link.Vel * Brake
+		local BrakeMult = sign(Link.Vel) * ACF.BrakeTorque * Brake
 
-		-- TODO: Add a proper method to deal with parking brakes
-		if Velocity < 1 then
-			BrakeMult = BrakeMult * (1 - Velocity)
-		end
-
-		Phys:ApplyTorqueCenter(TorqueAxis * Clamp(math.deg(-BrakeMult) * DeltaTime, -500000, 500000))
+		local MaxBrake = math.abs(Link.Vel * 100 * AxisInertia * DeltaTime)
+		Phys:ApplyTorqueCenter(TorqueAxis * Clamp(-BrakeMult * DeltaTime, -MaxBrake, MaxBrake))
 	end
 
 	function ENT:ApplyBrakes() -- This is just for brakes


### PR DESCRIPTION
Makes brakes apply constant torque, and clamps the torque so it doesn't invert the angular velocity (applies at most enough torque to stop the wheel).

This fixes wheels spazzing out at high brake inputs, and works a little more like it should irl