### PR TITLE
Move ACF_AmmoExplode and add ACF_AmmoCanCookOff

### DIFF
--- a/lua/acf/server/damage.lua
+++ b/lua/acf/server/damage.lua
@@ -604,10 +604,8 @@ do -- Remove Props ------------------------------
 		-- explode stuff last, so we don't re-process all that junk again in a new explosion
 		if next(Explosives) then
 			for Ent in pairs(Explosives) do
-				if Ent.Exploding then continue end
-
-				Ent.Exploding = true
 				Ent.Inflictor = Entity.Inflictor
+
 				Ent:Detonate()
 			end
 		end

--- a/lua/acf/shared/ammo/heat.lua
+++ b/lua/acf/shared/ammo/heat.lua
@@ -300,7 +300,6 @@ if SERVER then
 
 			-- If the target is explosive and the armor is penetrated, detonate
 			if Ent.Detonate then
-				Ent.Damaged = true
 				Ent:Detonate()
 			end
 

--- a/lua/entities/acf_ammo/init.lua
+++ b/lua/entities/acf_ammo/init.lua
@@ -402,6 +402,8 @@ end ---------------------------------------------
 
 do -- ACF Activation and Damage -----------------
 	local function CookoffCrate(Entity)
+		if HookRun("ACF_AmmoCanCookOff", Entity) == false then return Entity:Detonate() end
+
 		if Entity.Ammo <= 1 or Entity.Damaged < ACF.CurTime then -- Detonate when time is up or crate is out of ammo
 			Entity:Detonate()
 		elseif Entity.BulletData.Type ~= "Refill" and Entity.RoundData then -- Spew bullets out everywhere
@@ -460,8 +462,6 @@ do -- ACF Activation and Damage -----------------
 		if self.Exploding or not self.IsExplosive then return HitRes end
 
 		if HitRes.Kill then
-			if HookRun("ACF_AmmoExplode", self, self.BulletData) == false then return HitRes end
-
 			local Inflictor = Bullet.Owner
 
 			if IsValid(Inflictor) and Inflictor:IsPlayer() then
@@ -497,6 +497,7 @@ do -- ACF Activation and Damage -----------------
 	end
 
 	function ENT:Detonate()
+		if HookRun("ACF_AmmoExplode", self) == false then return end
 		if not self.Damaged then return end
 
 		self.Exploding = true

--- a/lua/entities/acf_ammo/init.lua
+++ b/lua/entities/acf_ammo/init.lua
@@ -402,7 +402,10 @@ end ---------------------------------------------
 
 do -- ACF Activation and Damage -----------------
 	local function CookoffCrate(Entity)
-		if HookRun("ACF_AmmoCanCookOff", Entity) == false then return Entity:Detonate() end
+		if HookRun("ACF_AmmoCanCookOff", Entity) == false then
+			Entity:Detonate()
+			return
+		end
 
 		if Entity.Ammo <= 1 or Entity.Damaged < ACF.CurTime then -- Detonate when time is up or crate is out of ammo
 			Entity:Detonate()
@@ -497,7 +500,11 @@ do -- ACF Activation and Damage -----------------
 	end
 
 	function ENT:Detonate()
-		if HookRun("ACF_AmmoExplode", self) == false then return end
+		if HookRun("ACF_AmmoExplode", self) == false then
+			timer.Remove("ACF Crate Cookoff " .. self:EntIndex())
+			self:Remove()
+			return
+		end
 		if not self.Damaged then return end
 
 		self.Exploding = true


### PR DESCRIPTION
Currently ACF_AmmoExplode doesn't prevent cook offs and only runs on hitres.Kill and there's no real way to only prevent cook offs. This pr aims to fix both issues.
