### PR TITLE
Stable brake overdrive

### DIFF
--- a/lua/entities/acf_gearbox/init.lua
+++ b/lua/entities/acf_gearbox/init.lua
@@ -216,11 +216,11 @@ do -- Spawn and Update functions -----------------------
 		if Entity.DualClutch then
 			List[Count + 1] = "Left Clutch (The amount of power allowed through the left side, inversely)"
 			List[Count + 2] = "Right Clutch (The amount of power allowed through the right side, inversely)"
-			List[Count + 3] = "Left Brake (The amount of braking (0-10000) to apply to the left side)"
-			List[Count + 4] = "Right Brake (The amount of braking (0-10000) to apply to the right side)"
+			List[Count + 3] = "Left Brake (The amount of braking to apply to the left side)"
+			List[Count + 4] = "Right Brake (The amount of braking to apply to the right side)"
 		else
 			List[Count + 1] = "Clutch (The amount of power to allow through the gearbox, inversely)"
-			List[Count + 2] = "Brake (The amount of braking (0-10000) to apply to any wheels attached)"
+			List[Count + 2] = "Brake (The amount of braking to apply to any wheels attached)"
 		end
 	end)
 	hook.Add("ACF_OnEntityLast", "ACF Cleanup Gearbox Data", function(Class, Gearbox)


### PR DESCRIPTION
Due to the backlash after the brake update, I worked out what I think is a better solution.

Brakes stay the same in the 0-100 range, but have their caps raised to 10,000. Cars will work perfectly with brakes up to 100, while tanks can make use of higher brake power. From my testing, they can stop and turn reliably now.

Overdriven brakes are also way more stable than old ACF-2 brakes. Even if you crank it up to 10k. Regarding spazz:

- The tanks I tested didn't spazz at all, even at max input.
- Cars only had their wheels spin back and forth slowly at max input (an improvement from the old impromptu space program).
- As long as cars use 0-100 input, no spazz is guaranteed.

The only changes that need to be made to existing vehicles is increasing the brake power, which should help.
Also, I think this should be merged to master as well, people were calling for a rollback, but this should fix things.