### PR TITLE
Added ACF_IsLegal hook

### DIFF
--- a/lua/acf/base/sv_validation.lua
+++ b/lua/acf/base/sv_validation.lua
@@ -41,11 +41,15 @@ local function IsLegal(Entity)
 	if Entity.IsACFWeapon and not ACF.GunsCanFire then return false, "Cannot fire", "Firing disabled by the servers ACF settings." end
 	if Entity.IsRack and not ACF.RacksCanFire then return false, "Cannot fire", "Firing disabled by the servers ACF settings." end
 
+	local Legal, Reason, Desc, OverrideIllegalTime = hook.Run("ACF_IsLegal",Entity)
+	if not Legal then return Legal, Reason, Desc, OverrideIllegalTime end
+
 	return true
 end
 
 local function CheckLegal(Entity)
-	local Legal, Reason, Description = IsLegal(Entity)
+	local Legal, Reason, Description, OverrideIllegalTime = IsLegal(Entity)
+	if OverrideIllegalTime then OverrideIllegalTime = math.max(OverrideIllegalTime,0.1) end
 
 	if not Legal then -- Not legal
 		if Reason ~= Entity.DisableReason then -- Only complain if the reason has changed
@@ -73,7 +77,7 @@ local function CheckLegal(Entity)
 			end
 		end
 
-		TimerSimple(ACF.IllegalDisableTime, function() -- Check if it's legal again in ACF.IllegalDisableTime
+		TimerSimple(OverrideIllegalTime or ACF.IllegalDisableTime, function() -- Check if it's legal again in ACF.IllegalDisableTime
 			if IsValid(Entity) and CheckLegal(Entity) then
 				Entity.Disabled	   	 = nil
 				Entity.DisableReason = nil


### PR DESCRIPTION
This is a simple hook to allow any external mods to control whether or not any ACF entity can function as normal
To simply allow them to run, return true
To disallow them, return
- false
- A short reason (e.g. Overweight)
- A description (e.g. You have exceeded the weight limit!)
- Optionally, a number that overrides the default recheck time with a minimum of 0.1s (default is 30s from being declared illegal, as set in acf_globals.lua)