### PR TITLE
Fuel consumption changed to account for power

### DIFF
--- a/lua/entities/acf_engine/init.lua
+++ b/lua/entities/acf_engine/init.lua
@@ -628,7 +628,6 @@ function ENT:GetConsumption(Throttle, RPM)
 		local IdleConsumption = self.PeakPower * 5e2
 		return self.FuelUse * (IdleConsumption + Throttle * self.Torque * RPM) / self.FuelTank.FuelDensity
 	end
-	
 end
 
 function ENT:CalcRPM()

--- a/lua/entities/acf_engine/init.lua
+++ b/lua/entities/acf_engine/init.lua
@@ -623,13 +623,12 @@ function ENT:GetConsumption(Throttle, RPM)
 	if not IsValid(self.FuelTank) then return 0 end
 
 	if self.FuelType == "Electric" then
-		Consumption = Throttle * self.FuelUse * self.Torque * RPM * 1.05e-4
+		return Throttle * self.FuelUse * self.Torque * RPM * 1.05e-4
 	else
 		local IdleConsumption = self.PeakPower * 5e2
-		Consumption = self.FuelUse * (IdleConsumption + Throttle * self.Torque * RPM) / self.FuelTank.FuelDensity
+		return self.FuelUse * (IdleConsumption + Throttle * self.Torque * RPM) / self.FuelTank.FuelDensity
 	end
-
-	return Consumption
+	
 end
 
 function ENT:CalcRPM()

--- a/lua/entities/acf_engine/init.lua
+++ b/lua/entities/acf_engine/init.lua
@@ -625,8 +625,8 @@ function ENT:GetConsumption(Throttle, RPM)
 	if self.FuelType == "Electric" then
 		Consumption = Throttle * self.FuelUse * self.Torque * RPM * 1.05e-4
 	else
-		local IdleConsumption = self.PeakPower * 4e-6
-		Consumption = (IdleConsumption + Throttle * self.FuelUse * self.Torque * RPM) / self.FuelTank.FuelDensity
+		local IdleConsumption = self.PeakPower * 5e2
+		Consumption = self.FuelUse * (IdleConsumption + Throttle * self.Torque * RPM) / self.FuelTank.FuelDensity
 	end
 
 	return Consumption

--- a/lua/entities/acf_engine/init.lua
+++ b/lua/entities/acf_engine/init.lua
@@ -305,7 +305,7 @@ do -- Spawn and Update functions
 		if EngineType.CalculateFuelUsage then
 			Entity.FuelUse = EngineType.CalculateFuelUsage(Entity)
 		else
-			Entity.FuelUse = ACF.FuelRate * Entity.Efficiency * Entity.PeakPower / 3600
+			Entity.FuelUse = ACF.FuelRate * Entity.Efficiency * 3e-8
 		end
 
 		ACF.Activate(Entity, true)
@@ -622,14 +622,11 @@ end
 function ENT:GetConsumption(Throttle, RPM)
 	if not IsValid(self.FuelTank) then return 0 end
 
-	local Consumption
-
 	if self.FuelType == "Electric" then
-		Consumption = self.Torque * RPM * self.FuelUse / 9548.8
+		Consumption = Throttle * self.FuelUse * self.Torque * RPM * 1.05e-4
 	else
-		local Load = 0.3 + Throttle * 0.7
-
-		Consumption = Load * self.FuelUse * (RPM / self.PeakPowerRPM) / self.FuelTank.FuelDensity
+		local IdleConsumption = self.PeakPower * 4e-6
+		Consumption = (IdleConsumption + Throttle * self.FuelUse * self.Torque * RPM) / self.FuelTank.FuelDensity
 	end
 
 	return Consumption


### PR DESCRIPTION
Changes the fuel consumption to be proportional to engine power and throttle, instead of RPM.

Did some quick research on BSFC (brake specific fuel consumption) of average piston engines, most plots look as such:

![image](https://user-images.githubusercontent.com/37046867/173268405-9a6c7615-79c5-4c31-9e2c-332de094cd11.png)

For all intents and purposes, that's a straight line across the RPM range, and so fuel consumption is calculated simply as throttle times power.

This is consistent with the [definition of BSFC](https://en.wikipedia.org/wiki/Brake-specific_fuel_consumption#The_BSFC_calculation_(in_metric_units)).

The constants were tweaked so that idle and peak fuel consumption remain roughly the same for the engines I tested.