### PR TITLE
Fix driver damage forwarding

### DIFF
--- a/lua/acf/server/damage.lua
+++ b/lua/acf/server/damage.lua
@@ -436,8 +436,10 @@ do -- Deal Damage ---------------------------
 		local Driver = Entity:GetDriver()
 
 		if IsValid(Driver) then
-			Trace.HitGroup = math.Rand(0, 7) -- Hit a random part of the driver
-			SquishyDamage(Bullet, Trace) -- Deal direct damage to the driver
+			local NewTrace = table.Copy(Trace)
+			NewTrace.Entity = Driver
+			NewTrace.HitGroup = math.Rand(0, 7) -- Hit a random part of the driver
+			SquishyDamage(Bullet, NewTrace) -- Deal direct damage to the driver
 		end
 
 		HitRes.Kill = false


### PR DESCRIPTION
The `SquishyDamage` call here is being given a Trace that hits a Vehicle, not a player.
That means the function double-damages the vehicle and never hits the driver.

This creates a new Trace object and updates it to pretend like it's hitting the driver before being passed into `SquishyDamage`.


I have not personally tested this yet.