### PR TITLE
Replaced call to ACF_RemoveBullet with a call to Ballistics.RemoveBullet in the AP ammo type

### DIFF
--- a/lua/acf/entities/ammo_types/ap.lua
+++ b/lua/acf/entities/ammo_types/ap.lua
@@ -168,7 +168,7 @@ if SERVER then
 	end
 
 	function Ammo:OnFlightEnd(Bullet)
-		ACF_RemoveBullet(Bullet)
+		Ballistics.RemoveBullet(Bullet)
 	end
 else
 	ACF.RegisterAmmoDecal("AP", "damage/ap_pen", "damage/ap_rico")


### PR DESCRIPTION
Noticed a ton of "attempt to call global ACF_RemoveBullet" after firing my coax and this seems to fix it.