### PR TITLE
ACF Check Driver before dealing damage

### DIFF
--- a/lua/acf/damage/damage_sv.lua
+++ b/lua/acf/damage/damage_sv.lua
@@ -437,7 +437,7 @@ do -- Deal Damage ---------------------------
 		local Entity = Trace.Entity
 		local Driver = Entity:GetDriver()
 
-		if IsValid(Driver) then
+		if IsValid(Driver) and ACF.Check(Driver) == "Squishy" then
 			local NewTrace = table.Copy(Trace)
 			NewTrace.Entity = Driver
 			NewTrace.HitGroup = math.Rand(0, 7) -- Hit a random part of the driver


### PR DESCRIPTION
If the Driver hasn't taken ACF damage before _(Specifically, hasn't been ACF Activated)_, it won't have an `ACF` table on it, causing the following error when the Vehicle takes damage:
```
addons/acf-3/lua/acf/server/damage.lua:362: attempt to index field 'ACF' (a nil value)
   0.  __index - [C]:-1
    1.  SquishyDamage - addons/acf-3/lua/acf/server/damage.lua:362
     2.  ACF_Damage - addons/acf-3/lua/acf/server/damage.lua:442
```