### PR TITLE
Return early if class data cant be found

### DIFF
--- a/lua/effects/acf_muzzle_flash.lua
+++ b/lua/effects/acf_muzzle_flash.lua
@@ -10,6 +10,7 @@ function EFFECT:Init(Data)
 	local Sound      = Gun:GetNWString("Sound")
 	local Class      = Gun:GetNWString("Class")
 	local ClassData  = Weapons.Get(Class)
+    if not ClassData then return end
 	local Attachment = "muzzle"
 	local LongBarrel = ClassData.LongBarrel
 

--- a/lua/effects/acf_muzzle_flash.lua
+++ b/lua/effects/acf_muzzle_flash.lua
@@ -10,7 +10,7 @@ function EFFECT:Init(Data)
 	local Sound      = Gun:GetNWString("Sound")
 	local Class      = Gun:GetNWString("Class")
 	local ClassData  = Weapons.Get(Class)
-    if not ClassData then return end
+	if not ClassData then return end
 	local Attachment = "muzzle"
 	local LongBarrel = ClassData.LongBarrel
 


### PR DESCRIPTION
Clientside error:
```
addons/acf-3/lua/effects/acf_muzzle_flash.lua:14: attempt to index local 'ClassData' (a nil value)
  1. unknown - addons/acf-3/lua/effects/acf_muzzle_flash.lua:14
```

This error has been happening for a while now and happens in large volumes usually in bursts of 30+ times in a row.
![image](https://user-images.githubusercontent.com/69946827/190833588-4d60a247-8a4b-4366-8325-f4e13dc35b30.png)
  