### PR TITLE
Check if entity is valid and remove unused local

### DIFF
--- a/lua/acf/ballistics/ballistics_sv.lua
+++ b/lua/acf/ballistics/ballistics_sv.lua
@@ -326,8 +326,9 @@ do -- Terminal ballistics --------------------------
 			)
 		end
 
+        print( Trace.Entity )
 		if HitRes.Kill and IsValid(Trace.Entity) then
-			ACF_APKill(Trace.Entity, Bullet.Flight:GetNormalized() , Energy.Kinetic)
+			ACF_APKill(Trace.Entity, Bullet.Flight:GetNormalized(), Energy.Kinetic)
 		end
 
 		HitRes.Ricochet = false

--- a/lua/acf/ballistics/ballistics_sv.lua
+++ b/lua/acf/ballistics/ballistics_sv.lua
@@ -326,10 +326,8 @@ do -- Terminal ballistics --------------------------
 			)
 		end
 
-		if HitRes.Kill then
-			local Debris = ACF_APKill(Trace.Entity, Bullet.Flight:GetNormalized() , Energy.Kinetic)
-
-			table.insert(Bullet.Filter , Debris)
+		if HitRes.Kill and IsValid(Trace.Entity) then
+			ACF_APKill(Trace.Entity, Bullet.Flight:GetNormalized() , Energy.Kinetic)
 		end
 
 		HitRes.Ricochet = false

--- a/lua/acf/ballistics/ballistics_sv.lua
+++ b/lua/acf/ballistics/ballistics_sv.lua
@@ -326,7 +326,6 @@ do -- Terminal ballistics --------------------------
 			)
 		end
 
-        print( Trace.Entity )
 		if HitRes.Kill and IsValid(Trace.Entity) then
 			ACF_APKill(Trace.Entity, Bullet.Flight:GetNormalized(), Energy.Kinetic)
 		end

--- a/lua/tests/acf/ballistics/ballistics_sv/do_round_impact.lua
+++ b/lua/tests/acf/ballistics/ballistics_sv/do_round_impact.lua
@@ -18,7 +18,9 @@ return {
             Flight = Vector( 1, 1, 1 )
         }
 
-        State.Trace = {}
+        State.Trace = {
+            IsValid = function() return true end
+        }
     end,
 
     cases = {
@@ -88,8 +90,21 @@ return {
                 ACF.Ballistics.DoRoundImpact( Bullet, Trace )
 
                 expect( State.ACF_APKill ).to.haveBeenCalled()
-                expect( #Bullet.Filter ).to.equal( 1 )
-                expect( Bullet.Filter[1] ).to.equal( State.ACF_APKill_Result )
+            end
+        },
+
+        {
+            name = "Does not call ACF_APKill when an invalid entity is killed",
+            func = function( State )
+                local Trace = State.Trace
+                Trace.Entity.IsValid = function() return false end
+
+                local Bullet = State.Bullet
+                State.ACF_Damage_Result.Kill = true
+
+                ACF.Ballistics.DoRoundImpact( Bullet, Trace )
+
+                expect( State.ACF_APKill ).notTo.haveBeenCalled()
             end
         }
     }

--- a/lua/tests/acf/ballistics/ballistics_sv/do_round_impact.lua
+++ b/lua/tests/acf/ballistics/ballistics_sv/do_round_impact.lua
@@ -102,7 +102,7 @@ return {
                 local Trace = State.Trace
                 local Bullet = State.Bullet
 
-                State.Entity.IsValid = function() return false end
+                State.Trace.Entity.IsValid = function() return false end
                 State.ACF_Damage_Result.Kill = true
 
                 ACF.Ballistics.DoRoundImpact( Bullet, Trace )

--- a/lua/tests/acf/ballistics/ballistics_sv/do_round_impact.lua
+++ b/lua/tests/acf/ballistics/ballistics_sv/do_round_impact.lua
@@ -18,9 +18,7 @@ return {
             Flight = Vector( 1, 1, 1 )
         }
 
-        State.Trace = {
-            IsValid = function() return true end
-        }
+        State.Trace = {}
     end,
 
     cases = {
@@ -85,11 +83,20 @@ return {
             func = function( State )
                 local Trace = State.Trace
                 local Bullet = State.Bullet
+
+                _IsValid = IsValid
+                IsValid = function() return true end
+
                 State.ACF_Damage_Result.Kill = true
 
                 ACF.Ballistics.DoRoundImpact( Bullet, Trace )
 
                 expect( State.ACF_APKill ).to.haveBeenCalled()
+            end
+
+            cleanup = function( State )
+                IsValid = _IsValid
+                _IsValid = nil
             end
         },
 
@@ -97,14 +104,21 @@ return {
             name = "Does not call ACF_APKill when an invalid entity is killed",
             func = function( State )
                 local Trace = State.Trace
-                Trace.Entity.IsValid = function() return false end
-
                 local Bullet = State.Bullet
+
+                _IsValid = IsValid
+                IsValid = function() return false end
+        
                 State.ACF_Damage_Result.Kill = true
 
                 ACF.Ballistics.DoRoundImpact( Bullet, Trace )
 
                 expect( State.ACF_APKill ).notTo.haveBeenCalled()
+            end
+
+            cleanup = function( State )
+                IsValid = _IsValid
+                _IsValid = nil
             end
         }
     }

--- a/lua/tests/acf/ballistics/ballistics_sv/do_round_impact.lua
+++ b/lua/tests/acf/ballistics/ballistics_sv/do_round_impact.lua
@@ -92,7 +92,7 @@ return {
                 ACF.Ballistics.DoRoundImpact( Bullet, Trace )
 
                 expect( State.ACF_APKill ).to.haveBeenCalled()
-            end
+            end,
 
             cleanup = function( State )
                 IsValid = _IsValid
@@ -114,7 +114,7 @@ return {
                 ACF.Ballistics.DoRoundImpact( Bullet, Trace )
 
                 expect( State.ACF_APKill ).notTo.haveBeenCalled()
-            end
+            end,
 
             cleanup = function( State )
                 IsValid = _IsValid

--- a/lua/tests/acf/ballistics/ballistics_sv/do_round_impact.lua
+++ b/lua/tests/acf/ballistics/ballistics_sv/do_round_impact.lua
@@ -18,7 +18,11 @@ return {
             Flight = Vector( 1, 1, 1 )
         }
 
-        State.Trace = {}
+        State.Trace = {
+            Entity = {
+                IsValid = function() return true end
+            }
+        }
     end,
 
     cases = {
@@ -84,19 +88,11 @@ return {
                 local Trace = State.Trace
                 local Bullet = State.Bullet
 
-                _IsValid = IsValid
-                IsValid = function() return true end
-
                 State.ACF_Damage_Result.Kill = true
 
                 ACF.Ballistics.DoRoundImpact( Bullet, Trace )
 
                 expect( State.ACF_APKill ).to.haveBeenCalled()
-            end,
-
-            cleanup = function( State )
-                IsValid = _IsValid
-                _IsValid = nil
             end
         },
 
@@ -106,19 +102,12 @@ return {
                 local Trace = State.Trace
                 local Bullet = State.Bullet
 
-                _IsValid = IsValid
-                IsValid = function() return false end
-        
+                State.Entity.IsValid = function() return false end
                 State.ACF_Damage_Result.Kill = true
 
                 ACF.Ballistics.DoRoundImpact( Bullet, Trace )
 
                 expect( State.ACF_APKill ).notTo.haveBeenCalled()
-            end,
-
-            cleanup = function( State )
-                IsValid = _IsValid
-                _IsValid = nil
             end
         }
     }


### PR DESCRIPTION
SV error:
```
addons/acf-3/lua/acf/damage/damage_sv.lua:671: Tried to use a NULL entity!
   0.  unkown - [C]:-1
    1.  GetPos - [C]:-1
     2.  ACF_APKill - addons/acf-3/lua/acf/damage/damage_sv.lua:671
      3.  DoRoundImpact - addons/acf-3/lua/acf/ballistics/ballistics_sv.lua:330
       4.  Func - addons/acf-3/lua/acf/entities/ammo_types/he.lua:94
        5.  OnImpact - addons/acf-3/lua/acf/ballistics/ballistics_sv.lua:170
         6.  DoBulletsFlight - addons/acf-3/lua/acf/ballistics/ballistics_sv.lua:270
          7.  CalcBulletFlight - addons/acf-3/lua/acf/ballistics/ballistics_sv.lua:87
           8.  CreateBullet - addons/acf-3/lua/acf/ballistics/ballistics_sv.lua:156
            9.  Detonate - addons/acf-3-missiles/lua/entities/acf_missile/init.lua:615
             10.  CalcFlight - addons/acf-3-missiles/lua/entities/acf_missile/init.lua:268
              11.  unkown - addons/acf-3-missiles/lua/entities/acf_missile/init.lua:625
```
and
```
addons/acf-3/lua/acf/damage/damage_sv.lua:671: Tried to use a NULL entity!
   1.  unknown - [C]:-1
    2.  GetPos - [C]:-1
     3.  ACF_APKill - addons/acf-3/lua/acf/damage/damage_sv.lua:671
      4.  DoRoundImpact - addons/acf-3/lua/acf/ballistics/ballistics_sv.lua:330
       5.  Func - addons/acf-3/lua/acf/entities/ammo_types/he.lua:94
        6.  OnImpact - addons/acf-3/lua/acf/ballistics/ballistics_sv.lua:170
         7.  DoBulletsFlight - addons/acf-3/lua/acf/ballistics/ballistics_sv.lua:270
          8.  CalcBulletFlight - addons/acf-3/lua/acf/ballistics/ballistics_sv.lua:87
           9.  CreateBullet - addons/acf-3/lua/acf/ballistics/ballistics_sv.lua:156
            10.  Create - addons/acf-3/lua/acf/entities/ammo_types/ap.lua:99
             11.  CookoffCrate - addons/acf-3/lua/entities/acf_ammo/init.lua:445
              12.  unknown - addons/acf-3/lua/entities/acf_ammo/init.lua:513
```

Removed the local and table insert as `ACF_APKill` never returns anything anyway
![image](https://user-images.githubusercontent.com/69946827/190900071-4d032128-8a9f-4ae2-b4c8-5e397ff78078.png)

The IsValid could also be placed in `ACF_APKill` itself but considering I've only seen this error happen through this line i felt like fixing it here would be better.