### PR TITLE
Add GLuaTest Test Suite badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Discord Invite](https://img.shields.io/discord/654142834030542878?label=Chat&style=flat-square)](https://discord.gg/jgdzysxjST)
 [![Steam Group](https://img.shields.io/badge/ACF%20Official-Join%20Now!-informational?style=flat-square)](https://steamcommunity.com/groups/officialacf)
 [![Linting Status](https://img.shields.io/github/workflow/status/Stooberton/ACF-3/GLuaFixer?label=Linter%20Status&style=flat-square)](https://github.com/Stooberton/ACF-3/actions?query=workflow%3AGLuaFixer)
+[![Test Suite](https://img.shields.io/github/workflow/status/Stooberton/ACF-3/GLuaTest%20Runner?label=Test%20Suite&style=flat-square)](https://github.com/CFC-Servers/GLuaTest)
 [![Repository Size](https://img.shields.io/github/repo-size/Stooberton/ACF-3?label=Repository%20Size&style=flat-square)](https://github.com/Stooberton/ACF-3)
 [![Commit Activity](https://img.shields.io/github/commit-activity/m/Stooberton/ACF-3?label=Commit%20Activity&style=flat-square)](https://github.com/Stooberton/ACF-3/graphs/commit-activity)
 


### PR DESCRIPTION
Just a simple PR to add a badge to the README. Clicking the badge takes the user to the GLuaTest repo - if you'd prefer this take them to the latest test run, I could concede to that.

Preview:
![image](https://user-images.githubusercontent.com/7936439/191589145-a70d3efd-c977-441b-b5e5-90ed6eb1e5b6.png)
