### PR TITLE
Fix/fix empty broadcast

### DIFF
--- a/lua/acf/core/networking/data_vars/data_vars_sv.lua
+++ b/lua/acf/core/networking/data_vars/data_vars_sv.lua
@@ -21,7 +21,7 @@ end
 local function SendQueued()
 	local Broadcast = Queued.Broadcast
 
-	if Broadcast then
+	if Broadcast and #player.GetAll() > 0 then
 		net.Start("ACF_DataVarNetwork")
 			net.WriteString(PrepareQueue("Broadcast", Server))
 		net.Broadcast()

--- a/lua/acf/core/networking/data_vars/data_vars_sv.lua
+++ b/lua/acf/core/networking/data_vars/data_vars_sv.lua
@@ -21,10 +21,12 @@ end
 local function SendQueued()
 	local Broadcast = Queued.Broadcast
 
-	if Broadcast and #player.GetAll() > 0 then
-		net.Start("ACF_DataVarNetwork")
-			net.WriteString(PrepareQueue("Broadcast", Server))
-		net.Broadcast()
+	if Broadcast then
+		if #player.GetAll() > 0 then
+			net.Start("ACF_DataVarNetwork")
+				net.WriteString(PrepareQueue("Broadcast", Server))
+			net.Broadcast()
+		end
 
 		Queued.Broadcast = nil
 	end


### PR DESCRIPTION
This should fix this error on startup:
```
Warning! Trying to net.Broadcast a message 'ACF_DataVarNetwork' with no players on server!
```