### PR TITLE
Torch updates, AP/HEKill updates

### DIFF
--- a/lua/acf/ballistics/ballistics_sv.lua
+++ b/lua/acf/ballistics/ballistics_sv.lua
@@ -319,7 +319,7 @@ do -- Terminal ballistics --------------------------
 		end
 
 		if HitRes.Kill and IsValid(Entity) then
-			ACF.APKill(Entity, Bullet.Flight:GetNormalized(), Energy.Kinetic)
+			ACF.APKill(Entity, Bullet.Flight:GetNormalized(), Energy.Kinetic, DmgInfo)
 		end
 
 		HitRes.Ricochet = false

--- a/lua/acf/damage/debris_sv.lua
+++ b/lua/acf/damage/debris_sv.lua
@@ -149,7 +149,7 @@ function ACF.HEKill(Entity, Normal, Energy, BlastPos, DmgInfo) -- blast pos is a
 
 		Entity:PrecacheGibs()
 		Entity:GibBreakClient(Vector())
-		
+
 		Entity:TakeDamageInfo(dmg)
 	else
 		Entity:Remove()
@@ -176,7 +176,7 @@ function ACF.APKill(Entity, Normal, Power, DmgInfo)
 
 		Entity:PrecacheGibs()
 		Entity:GibBreakClient(Vector())
-		
+
 		Entity:TakeDamageInfo(dmg)
 	else
 		Entity:Remove()

--- a/lua/acf/damage/explosion_sv.lua
+++ b/lua/acf/damage/explosion_sv.lua
@@ -199,7 +199,7 @@ function Damage.createExplosion(Position, FillerMass, FragMass, Filter, DmgInfo)
 						Targets[HitEnt]     = nil -- Remove from list
 
 						if FragKill then
-							ACF.APKill(HitEnt, Direction, PowerFraction)
+							ACF.APKill(HitEnt, Direction, PowerFraction, DmgInfo)
 						else
 							local Debris = ACF.HEKill(HitEnt, Direction, PowerFraction, Position)
 

--- a/lua/acf/entities/ammo_types/heat.lua
+++ b/lua/acf/entities/ammo_types/heat.lua
@@ -314,7 +314,7 @@ if SERVER then
 				local JetResult = Damage.dealDamage(Ent, JetDmg, JetInfo)
 
 				if JetResult.Kill then
-					local Debris = ACF.APKill(Ent, Direction, 0)
+					local Debris = ACF.APKill(Ent, Direction, 0, JetInfo)
 
 					table.insert(Filter , Debris)
 				end
@@ -385,7 +385,7 @@ if SERVER then
 				local JetResult = Damage.dealDamage(Ent, SpallDmg, SpallInfo)
 
 				if JetResult.Kill then
-					local Debris = ACF.APKill(Entity, Direction, 0)
+					local Debris = ACF.APKill(Entity, Direction, 0, SpallInfo)
 
 					table.insert(Filter , Debris)
 				end

--- a/lua/weapons/acf_torch/cl_init.lua
+++ b/lua/weapons/acf_torch/cl_init.lua
@@ -24,7 +24,7 @@ function SWEP:PostDrawViewModel()
 	local Armor = math.Round(self:GetNWFloat("Armour", 0), 2)
 	local MaxArmor = math.Round(self:GetNWFloat("MaxArmour", 0), 2)
 
-	local Flicker = math.random(100, 150)
+	local Flicker = math.random(220, 240)
 	local TextColor = Color(224, 224, 255, Flicker)
 	local OutColor = Color(0, 0, 0, Flicker)
 
@@ -39,20 +39,29 @@ function SWEP:PostDrawViewModel()
 
 	render.SetRenderTarget(RT)
 	render.SetViewPort(0, 0, 256, 256)
+	render.Clear(0,0,0,255)
 
 	cam.Start2D()
 		surface.SetTexture(Texture)
 		surface.DrawTexturedRect(0, 0, 256, 256)
 		surface.SetDrawColor(255, 255, 255, Flicker)
-		draw.SimpleTextOutlined("ACF Stats", "torchfont", 128, 30, TextColor, Center, Center, 4, OutColor)
-		draw.RoundedBox(5, 10, 83, 236, 64, Color(200, 200, 200, Flicker))
-		draw.RoundedBox(5, 15, 88, ArmorRatio * 226, 54, Color(0, 0, 200, Flicker))
-		draw.RoundedBox(5, 10, 183, 236, 64, Color(200, 200, 200, Flicker))
-		draw.RoundedBox(5, 15, 188, HealthRatio * 226, 54, Color(200, 0, 0, Flicker))
-		draw.SimpleTextOutlined("Armor", "torchfont", 128, 100, TextColor, Center, Center, 4, OutColor)
-		draw.SimpleTextOutlined(ArmorText, "torchfont", 128, 150, TextColor, Center, Center, 4, OutColor)
-		draw.SimpleTextOutlined("Health", "torchfont", 128, 200, TextColor, Center, Center, 4, OutColor)
-		draw.SimpleTextOutlined(HealthText, "torchfont", 128, 250, TextColor, Center, Center, 4, OutColor)
+		draw.SimpleTextOutlined("ACF Stats", "torchfont", 128, 48, TextColor, Center, Center, 4, OutColor)
+
+		if MaxHealth > 0 then
+			if MaxArmor > 0  then
+				draw.RoundedBox(5, 10, 83, 236, 64, Color(200, 200, 200, Flicker))
+				draw.RoundedBox(5, 15, 88, ArmorRatio * 226, 54, Color(0, 0, 200, Flicker))
+				draw.SimpleTextOutlined("Armor", "torchfont", 128, 100, TextColor, Center, Center, 4, OutColor)
+				draw.SimpleTextOutlined(ArmorText, "torchfont", 128, 150, TextColor, Center, Center, 4, OutColor)
+			end
+
+			draw.RoundedBox(5, 10, 183, 236, 64, Color(200, 200, 200, Flicker))
+			draw.RoundedBox(5, 15, 188, HealthRatio * 226, 54, Color(200, 0, 0, Flicker))
+			draw.SimpleTextOutlined("Health", "torchfont", 128, 200, TextColor, Center, Center, 4, OutColor)
+			draw.SimpleTextOutlined(HealthText, "torchfont", 128, 250, TextColor, Center, Center, 4, OutColor)
+		else
+			draw.SimpleTextOutlined("NO TARGET", "torchfont", 128, 140, TextColor, Center, Center, 4, OutColor)
+		end
 	cam.End2D()
 
 	render.SetRenderTarget(OldRT)

--- a/lua/weapons/acf_torch/shared.lua
+++ b/lua/weapons/acf_torch/shared.lua
@@ -3,6 +3,7 @@ AddCSLuaFile("shared.lua")
 
 local ACF     = ACF
 local Clock   = ACF.Utilities.Clock
+local Network = ACF.Networking
 local Damage  = ACF.Damage
 local Objects = Damage.Objects
 local Spark   = "ambient/energy/NewSpark0%s.wav"
@@ -251,6 +252,8 @@ function SWEP:PrimaryAttack()
 		Entity.ACF.Health = Health
 		Entity.ACF.Armour = Armor
 
+		Network.Broadcast("ACF_Damage", Entity) -- purely to update the damage material on props
+
 		if Entity.ACF_OnRepaired then
 			Entity:ACF_OnRepaired(OldArmor, OldHealth, Armor, Health)
 		end
@@ -291,7 +294,7 @@ function SWEP:SecondaryAttack()
 	local HitRes = Damage.dealDamage(Entity, DmgResult, self.DamageInfo)
 
 	if HitRes.Kill then
-		ACF.APKill(Entity, Trace.Normal, 1)
+		ACF.APKill(Entity, Trace.Normal, 1, DmgInfo)
 	else
 		local Effect = EffectData()
 		Effect:SetMagnitude(1)


### PR DESCRIPTION
Made the screen on the torch less pain to read
Damage material also fades away if a prop is repaired

Destroying a breakable prop (boxes, barrels, etc..) will now try to break the prop instead of just using ACF's debris system, but only if it is actually breakable, otherwise it defaults to said debris system