### PR TITLE
Change return order for performance.

### DIFF
--- a/lua/weapons/gmod_tool/stools/acfarmorprop.lua
+++ b/lua/weapons/gmod_tool/stools/acfarmorprop.lua
@@ -281,11 +281,13 @@ if CLIENT then
 
 	hook.Add("PostDrawOpaqueRenderables", "Armor Tool Search Sphere", function()
 		local Player = LocalPlayer()
-		local Tool = Player:GetTool()
+		local Weapon = Player:GetActiveWeapon()
+		if not Weapon then return end
+		if Weapon:GetClass() ~= "gmod_tool" then return end
 
+		local Tool = Player:GetTool()
 		if not Tool then return end -- Player has no toolgun
 		if Tool ~= Player:GetTool("acfarmorprop") then return end -- Current tool is not the armor tool
-		if Tool.Weapon ~= Player:GetActiveWeapon() then return end -- Player is not holding the toolgun
 		if not Sphere:GetBool() then return end
 
 		local Value = Radius:GetFloat()

--- a/lua/weapons/gmod_tool/stools/acfarmorprop.lua
+++ b/lua/weapons/gmod_tool/stools/acfarmorprop.lua
@@ -1,4 +1,5 @@
 local ACF = ACF
+local IsValid = IsValid
 
 TOOL.Category	= (ACF.CustomToolCategory and ACF.CustomToolCategory:GetBool()) and "ACF" or "Construction"
 TOOL.Name		= "#tool.acfarmorprop.name"
@@ -282,7 +283,7 @@ if CLIENT then
 	hook.Add("PostDrawOpaqueRenderables", "Armor Tool Search Sphere", function()
 		local Player = LocalPlayer()
 		local Weapon = Player:GetActiveWeapon()
-		if not Weapon then return end
+		if not IsValid( Weapon ) then return end
 		if Weapon:GetClass() ~= "gmod_tool" then return end
 
 		local Tool = Player:GetTool()


### PR DESCRIPTION
During some performance testing i noticed that this acf hook kept popping up in fprofiler, after some investigation i found that `:GetTool()` seems to be the cause. This pr makes it so that ActiveWeapon is first checked then GetTool. This pr will certainly save tenths of fps.

Test code:
```lua
local function original()
    	local Player = LocalPlayer()
    	local Tool = Player:GetTool()

    	if not Tool then return end -- Player has no toolgun
    	if Tool ~= Player:GetTool("acfarmorprop") then return end -- Current tool is not the armor tool
    	if Tool.Weapon ~= Player:GetActiveWeapon() then return end -- Player is not holding the toolgun
    	if not Sphere:GetBool() then return end
end

local function new()
	local Player = LocalPlayer()
	local Weapon = Player:GetActiveWeapon()
	if not Weapon then return end
	if Weapon:GetClass() ~= "gmod_tool" then return end

	local Tool = Player:GetTool()
	if not Tool then return end -- Player has no toolgun
	if Tool ~= Player:GetTool("acfarmorprop") then return end -- Current tool is not the armor tool
	if not Sphere:GetBool() then return end
end

GMN.TestCompare( original, new, 100000 )
```

Result:
```
[GMN] Starting test..
1 JIT ON took 1.1782613999999 seconds to run 100000 times, average: 1.1782613999999e-05 seconds
2 JIT ON took 0.016893999999866 seconds to run 100000 times, average: 1.6893999999866e-07 seconds
1 JIT OFF took 1.1679328 seconds to run 100000 times, average: 1.1679328e-05 seconds
2 JIT OFF took 0.020173700000214 seconds to run 100000 times, average: 2.0173700000214e-07 seconds
JIT ON 2 is 6874.437% faster than test 1
JIT OFF 2 is 5689.383% faster than test 1
```

Example 2:
```lua
local function original()
    		local Player = LocalPlayer()
    		local Tool = Player:GetTool()
      if not Tool then return end -- Player has no toolgun
    	 if Tool ~= Player:GetTool("acfarmorprop") then return end -- Current tool is not the armor tool
end

local function new()
				local Player = LocalPlayer()
				local Weapon = Player:GetActiveWeapon()
    if not Weapon then return end
    if Weapon:GetClass() ~= "gmod_tool" then return end
end

GMN.TestCompare( original, new, 100000 )
```
```
[GMN] Starting test..
1 JIT ON took 1.1529964000001 seconds to run 100000 times, average: 1.1529964000001e-05 seconds
2 JIT ON took 0.016761100000167 seconds to run 100000 times, average: 1.6761100000167e-07 seconds
1 JIT OFF took 1.1812250999997 seconds to run 100000 times, average: 1.1812250999997e-05 seconds
2 JIT OFF took 0.022479499999918 seconds to run 100000 times, average: 2.2479499999918e-07 seconds
JIT ON 2 is 6779.002% faster than test 1
JIT OFF 2 is 5154.677% faster than test 1
```

Test lib used: <https://github.com/CFC-Servers/gm_nitrous/blob/add-initial-code/lua/nitrous/utils/testlib.lua>