### PR TITLE
Prevent improper sound paths

### DIFF
--- a/lua/weapons/gmod_tool/stools/acfsound.lua
+++ b/lua/weapons/gmod_tool/stools/acfsound.lua
@@ -80,6 +80,7 @@ local function ReplaceSound(_, Entity, Data)
 	local Sound, Pitch = unpack(Data)
 
 	if not Support then return end
+	if not file.Exists("sound/" .. Sound, "GAME") then return end
 
 	timer.Simple(1, function()
 		Support.SetSound(Entity, {
@@ -115,7 +116,13 @@ end
 function TOOL:LeftClick(trace)
 	if CLIENT then return true end
 	if not IsReallyValid(trace, self:GetOwner()) then return false end
+
 	local sound = self:GetOwner():GetInfo("wire_soundemitter_sound")
+	if not file.Exists("sound/" .. sound, "GAME") then
+		ACF.SendNotify(self:GetOwner(), false, "Sound file not found!")
+		return false
+	end
+
 	local pitch = self:GetOwner():GetInfo("acfsound_pitch")
 	ReplaceSound(self:GetOwner(), trace.Entity, {sound, pitch})
 


### PR DESCRIPTION
Trying to play invalid sound paths can really destroy the server console.

Sometimes this duplicator mod seems to default to `"0"` for some reason, so that makes it especially bad.

This PR prevents players from setting sounds that don't exist on the server, and prevents dupes from loading sounds that don't exist on the server.


(not tested but it's pretty straightforward?)