### PR TITLE
Move sound restrictions to point-of-use

### DIFF
--- a/lua/entities/acf_engine/init.lua
+++ b/lua/entities/acf_engine/init.lua
@@ -194,7 +194,7 @@ local function SetActive(Entity, Value)
 
 		local Pitch, Volume = GetPitchVolume(Entity)
 
-		if Entity.SoundPath ~= "" then
+		if Entity.SoundPath ~= "" and file.Exists("sound/" .. Entity.SoundPath, "GAME") then
 			Entity.Sound = CreateSound(Entity, Entity.SoundPath)
 			Entity.Sound:PlayEx(Volume, Pitch)
 		end

--- a/lua/entities/acf_gearbox/init.lua
+++ b/lua/entities/acf_gearbox/init.lua
@@ -718,7 +718,9 @@ do -- Gear Shifting ------------------------------------
 		self.GearRatio      = self.Gears[Value] * self.FinalDrive
 		self.ChangeFinished = Clock.CurTime + self.SwitchTime
 
-		self:EmitSound(self.SoundPath, 70, 100, 0.5 * ACF.Volume)
+		if self.SoundPath ~= "" and file.Exists("sound/" .. self.SoundPath, "GAME") then
+			self:EmitSound(self.SoundPath, 70, 100, 0.5 * ACF.Volume)
+		end
 
 		WireLib.TriggerOutput(self, "Current Gear", Value)
 		WireLib.TriggerOutput(self, "Ratio", self.GearRatio)

--- a/lua/entities/acf_piledriver/init.lua
+++ b/lua/entities/acf_piledriver/init.lua
@@ -343,7 +343,9 @@ do -- Firing ------------------------------------
 			local Sound  = self.SoundPath or Impact:format(math.random(5, 6))
 			local Bullet = self.BulletData
 
-			self:EmitSound(Sound, 70, math.Rand(98, 102), ACF.Volume)
+			if Sound ~= "" and file.Exists("sound/" .. Sound, "GAME") then
+				self:EmitSound(Sound, 70, math.Rand(98, 102), ACF.Volume)
+			end
 			self:SetSequence("load")
 
 			Bullet.Owner  = self:GetUser(self.Inputs.Fire.Src) -- Must be updated on every shot

--- a/lua/weapons/gmod_tool/stools/acfsound.lua
+++ b/lua/weapons/gmod_tool/stools/acfsound.lua
@@ -80,7 +80,6 @@ local function ReplaceSound(_, Entity, Data)
 	local Sound, Pitch = unpack(Data)
 
 	if not Support then return end
-	if not file.Exists("sound/" .. Sound, "GAME") then return end
 
 	timer.Simple(1, function()
 		Support.SetSound(Entity, {
@@ -116,13 +115,7 @@ end
 function TOOL:LeftClick(trace)
 	if CLIENT then return true end
 	if not IsReallyValid(trace, self:GetOwner()) then return false end
-
 	local sound = self:GetOwner():GetInfo("wire_soundemitter_sound")
-	if not file.Exists("sound/" .. sound, "GAME") then
-		ACF.SendNotify(self:GetOwner(), false, "Sound file not found!")
-		return false
-	end
-
 	local pitch = self:GetOwner():GetInfo("acfsound_pitch")
 	ReplaceSound(self:GetOwner(), trace.Entity, {sound, pitch})
 


### PR DESCRIPTION
Instead of restricting the tool from setting the sounds, it was suggested that we restrict the entities from _playing_ invalid sounds.