### PR TITLE
Chore: Update GLuaTest syntax

### DIFF
--- a/lua/tests/acf/ballistics/ballistics_sv/do_round_impact.lua
+++ b/lua/tests/acf/ballistics/ballistics_sv/do_round_impact.lua
@@ -45,8 +45,8 @@ return {
                 local HitRes = ACF.Ballistics.DoRoundImpact( Bullet, Trace )
 
                 expect( HitRes.Ricochet ).to.equal( true )
-                expect( GetRicochetVector ).to.haveBeenCalled()
-                expect( CalculateRicochet ).to.haveBeenCalled()
+                expect( GetRicochetVector ).was.called()
+                expect( CalculateRicochet ).was.called()
             end
         },
 
@@ -61,7 +61,7 @@ return {
 
                 ACF.Ballistics.DoRoundImpact( Bullet, Trace )
 
-                expect( State.ACF_KEShove ).to.haveBeenCalled()
+                expect( State.ACF_KEShove ).was.called()
             end,
 
             cleanup = function( State )
@@ -80,7 +80,7 @@ return {
 
                 ACF.Ballistics.DoRoundImpact( Bullet, Trace )
 
-                expect( State.ACF_KEShove ).toNot.haveBeenCalled()
+                expect( State.ACF_KEShove ).wasNot.called()
             end,
 
             cleanup = function( State )
@@ -98,7 +98,7 @@ return {
 
                 ACF.Ballistics.DoRoundImpact( Bullet, Trace )
 
-                expect( State.ACF_APKill ).to.haveBeenCalled()
+                expect( State.ACF_APKill ).was.called()
             end
         },
 
@@ -113,7 +113,7 @@ return {
 
                 ACF.Ballistics.DoRoundImpact( Bullet, Trace )
 
-                expect( State.ACF_APKill ).notTo.haveBeenCalled()
+                expect( State.ACF_APKill ).wasNot.called()
             end
         }
     }

--- a/lua/tests/acf/ballistics/ballistics_sv/on_impact.lua
+++ b/lua/tests/acf/ballistics/ballistics_sv/on_impact.lua
@@ -20,8 +20,8 @@ return {
                 local Type = "World"
 
                 ACF.Ballistics.OnImpact( Bullet, Trace, Ammo, Type )
-                expect( Ammo.WorldImpact ).to.haveBeenCalled()
-                expect( Ammo.PropImpact ).toNot.haveBeenCalled()
+                expect( Ammo.WorldImpact ).was.called()
+                expect( Ammo.PropImpact ).wasNot.called()
             end
         },
 
@@ -38,8 +38,8 @@ return {
                 local Type = "Test"
 
                 ACF.Ballistics.OnImpact( Bullet, Trace, Ammo, Type )
-                expect( Ammo.WorldImpact ).toNot.haveBeenCalled()
-                expect( Ammo.PropImpact ).to.haveBeenCalled()
+                expect( Ammo.WorldImpact ).wasNot.called()
+                expect( Ammo.PropImpact ).was.called()
             end
         },
 
@@ -52,7 +52,7 @@ return {
                 local Type = "Test"
 
                 ACF.Ballistics.OnImpact( Bullet, Trace, Ammo, Type )
-                expect( Bullet.OnPenetrated ).to.haveBeenCalled()
+                expect( Bullet.OnPenetrated ).was.called()
             end
         },
 
@@ -65,7 +65,7 @@ return {
                 local Type = "Test"
 
                 ACF.Ballistics.OnImpact( Bullet, Trace, Ammo, Type )
-                expect( Bullet.OnRicocheted ).to.haveBeenCalled()
+                expect( Bullet.OnRicocheted ).was.called()
             end
         },
 
@@ -81,7 +81,7 @@ return {
                 local Type = "Test"
 
                 ACF.Ballistics.OnImpact( Bullet, Trace, Ammo, Type )
-                expect( Bullet.OnEndFlight ).to.haveBeenCalled()
+                expect( Bullet.OnEndFlight ).was.called()
             end
         }
     }

--- a/lua/tests/acf/core/validation_sv/acf_activate.lua
+++ b/lua/tests/acf/core/validation_sv/acf_activate.lua
@@ -49,7 +49,7 @@ return {
                 stub( ACF, "GetEntityType" ).returns( "TestType" )
 
                 ACF.Activate( Ent )
-                expect( Ent.ACF_Activate ).to.haveBeenCalled()
+                expect( Ent.ACF_Activate ).was.called()
                 expect( Ent.ACF.Type ).to.equal( "TestType" )
             end
         },

--- a/lua/tests/acf/core/validation_sv/acf_check.lua
+++ b/lua/tests/acf/core/validation_sv/acf_check.lua
@@ -76,7 +76,7 @@ return {
                 local Activate = stub( ACF, "Activate" )
 
                 expect( ACF.Check( Ent ) ).to.beFalse()
-                expect( Activate ).notTo.haveBeenCalled()
+                expect( Activate ).wasNot.called()
             end
         },
 
@@ -91,7 +91,7 @@ return {
                 local Activate = stub( ACF, "Activate" )
 
                 expect( ACF.Check( Ent ) ).to.beFalse()
-                expect( Activate ).notTo.haveBeenCalled()
+                expect( Activate ).wasNot.called()
             end
         },
 
@@ -105,7 +105,7 @@ return {
                 local Activate = stub( ACF, "Activate" )
 
                 expect( ACF.Check( Ent ) ).to.beFalse()
-                expect( Activate ).notTo.haveBeenCalled()
+                expect( Activate ).wasNot.called()
             end
         },
 
@@ -120,7 +120,7 @@ return {
                 end )
 
                 expect( ACF.Check( Ent ) ).to.equal( "Test" )
-                expect( Activate ).to.haveBeenCalled()
+                expect( Activate ).was.called()
             end
         },
 
@@ -134,7 +134,7 @@ return {
                 end )
 
                 expect( ACF.Check( Ent, true ) ).to.equal( "Test" )
-                expect( Activate ).to.haveBeenCalled()
+                expect( Activate ).was.called()
             end
         },
 
@@ -149,7 +149,7 @@ return {
                 end )
 
                 expect( ACF.Check( Ent ) ).to.equal( "Test" )
-                expect( Activate ).to.haveBeenCalled()
+                expect( Activate ).was.called()
             end
         },
 
@@ -164,7 +164,7 @@ return {
                 end )
 
                 expect( ACF.Check( Ent ) ).to.equal( "Test" )
-                expect( Activate ).to.haveBeenCalled()
+                expect( Activate ).was.called()
             end
         }
     }

--- a/lua/tests/acf/damage/damage_sv/acf_damage.lua
+++ b/lua/tests/acf/damage/damage_sv/acf_damage.lua
@@ -79,7 +79,7 @@ return {
 
                 ACF.Damage.dealDamage( Ent, State.DmgResult, nil )
 
-                expect( Ent.ACF_OnDamage ).to.haveBeenCalled()
+                expect( Ent.ACF_OnDamage ).was.called()
             end
         },
 
@@ -92,7 +92,7 @@ return {
 
                 ACF.Damage.dealDamage( State.Ent, State.DmgResult, nil )
 
-                expect( PropDamage ).to.haveBeenCalled()
+                expect( PropDamage ).was.called()
             end
         },
 
@@ -105,7 +105,7 @@ return {
 
                 ACF.Damage.dealDamage( State.Ent, State.DmgResult, nil )
 
-                expect( VehicleDamage ).to.haveBeenCalled()
+                expect( VehicleDamage ).was.called()
             end
         },
 
@@ -118,7 +118,7 @@ return {
 
                 ACF.Damage.dealDamage( State.Ent, State.DmgResult, nil )
 
-                expect( SquishyDamage ).to.haveBeenCalled()
+                expect( SquishyDamage ).was.called()
             end
         }
     }

--- a/lua/tests/acf/damage/damage_sv/acf_keshove.lua
+++ b/lua/tests/acf/damage/damage_sv/acf_keshove.lua
@@ -34,7 +34,7 @@ return {
 
                 ACF.KEShove( Ent, Ones, Ones, 1 )
 
-                expect( State.applyForceStub ).to.haveBeenCalled()
+                expect( State.applyForceStub ).was.called()
             end
         },
 
@@ -46,7 +46,7 @@ return {
 
                 ACF.KEShove( Ent, Ones, Ones, 1 )
 
-                expect( State.applyForceStub ).toNot.haveBeenCalled()
+                expect( State.applyForceStub ).wasNot.called()
             end
         },
         {
@@ -57,7 +57,7 @@ return {
 
                 ACF.KEShove( Ent, Ones, Ones, 1 )
 
-                expect( State.applyForceStub ).toNot.haveBeenCalled()
+                expect( State.applyForceStub ).wasNot.called()
             end,
 
             cleanup = function()
@@ -74,7 +74,7 @@ return {
                 local calcMass = stub( _G, "ACF_CalcMassRatio" )
                 ACF.KEShove( Ent, Ones, Ones, 1 )
 
-                expect( calcMass ).to.haveBeenCalled()
+                expect( calcMass ).was.called()
             end
         },
 
@@ -87,7 +87,7 @@ return {
                 local calcMass = stub( _G, "ACF_CalcMassRatio" )
                 ACF.KEShove( Ent, Ones, Ones, 1 )
 
-                expect( calcMass ).to.haveBeenCalled()
+                expect( calcMass ).was.called()
             end
         }
     }


### PR DESCRIPTION
We updated some GLuaTest expectations. The current tests still work, but I updated the deprecated calls.