### PR TITLE
Fix GearRatio sometimes not updating properly

### DIFF
--- a/lua/entities/acf_gearbox/init.lua
+++ b/lua/entities/acf_gearbox/init.lua
@@ -150,6 +150,9 @@ do -- Spawn and Update functions -----------------------
 		end
 
 		Entity:ChangeGear(1)
+
+		-- ChangeGear doesn't update GearRatio if the gearbox is already in gear 1
+		Entity.GearRatio = Entity.Gears[1] * Entity.FinalDrive
 	end
 
 	local function CheckRopes(Entity, Target)


### PR DESCRIPTION
This fixes the long-standing issue where you need to dupe and respawn differentials in order for them to update properly. ChangeGear(1), as used at the end of UpdateGearbox, does not update GearRatio if the gear is already 1.