### PR TITLE
E2/SF ACF Class function

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
@@ -112,6 +112,14 @@ e2function string entity:acfType()
 	return this.EntType or ""
 end
 
+-- Returns the class of ACF entity
+e2function string entity:acfClass()
+	if not IsACFEntity(this) then return "" end
+	if RestrictInfo(self, this) then return "" end
+
+	return this.Class or ""
+end
+
 -- Returns 1 if the entity is an ACF engine
 e2function number entity:acfIsEngine()
 	if not validPhysics(this) then return 0 end

--- a/lua/entities/gmod_wire_expression2/core/custom/cl_acfdescriptions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_acfdescriptions.lua
@@ -6,6 +6,7 @@ E2Desc["acfInfoRestricted()"] = "Returns 1 if functions are not returning sensit
 E2Desc["acfName(e:)"] = "Returns the full name of an ACF entity."
 E2Desc["acfNameShort(e:)"] = "Returns the short name of an ACF entity."
 E2Desc["acfType(e:)"] = "Returns the type of ACF entity."
+E2Desc["acfClass(e:)"] = "Returns the class of ACF entity."
 E2Desc["acfIsEngine(e:)"] = "Returns 1 if the entity is an ACF engine."
 E2Desc["acfIsGearbox(e:)"] = "Returns 1 if the entity is an ACF gearbox."
 E2Desc["acfIsGun(e:)"] = "Returns 1 if the entity is an ACF gun."

--- a/lua/starfall/libs_sh/acffunctions.lua
+++ b/lua/starfall/libs_sh/acffunctions.lua
@@ -773,6 +773,20 @@ if SERVER then
 		return This.EntType or ""
 	end
 
+	--- Returns the class of ACF entity
+	-- @server
+	-- @return string The class of the entity
+	function ents_methods:acfClass()
+		CheckType(self, ents_metatable)
+
+		local This = unwrap(self)
+
+		if not IsACFEntity(This) then SF.Throw("Entity is not valid", 2) end
+		if RestrictInfo(This) then return "" end
+
+		return This.Class or ""
+	end
+
 	--- Returns true if the entity is an ACF engine
 	-- @server
 	-- @return boolean True if the entity is an ACF engine


### PR DESCRIPTION
Adds a function for both E2 and Starfall that allows one to directly grab the class of an ACF entity, for example using this on a TOW missile ammo crate would return ATGM, as opposed to someone needing to explode the name to collect relevant info. This can further aid in getting specifics about an entity without having to dissect the name, which was ridiculous to leave as-is.

Usage: Entity:acfClass()
Returns: string Entity.Class (as written by ACF)