### PR TITLE
Modify APHE penetration

### DIFF
--- a/lua/acf/entities/ammo_types/aphe.lua
+++ b/lua/acf/entities/ammo_types/aphe.lua
@@ -18,6 +18,14 @@ function Ammo:OnLoaded()
 	}
 end
 
+function Ammo:GetPenetration(Bullet, Speed)
+	if not isnumber(Speed) then
+		Speed = Bullet.Flight and Bullet.Flight:Length() / ACF.Scale * 0.0254 or Bullet.MuzzleVel
+	end
+
+	return ACF.Penetration(Speed, Bullet.ProjMass, Bullet.Diameter * 10) * (1 - Bullet.FillerRatio)
+end
+
 function Ammo:GetDisplayData(Data)
 	local Display  = Ammo.BaseClass.GetDisplayData(self, Data)
 	local FragMass = Data.ProjMass - Data.FillerMass
@@ -45,6 +53,7 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 	Data.MuzzleVel  = ACF.MuzzleVelocity(Data.PropMass, Data.ProjMass, Data.Efficiency)
 	Data.DragCoef   = Data.ProjArea * 0.0001 / Data.ProjMass
 	Data.CartMass   = Data.PropMass + Data.ProjMass
+	Data.FillerRatio = math.Clamp(ToolData.FillerRatio, 0, 1)
 
 	hook.Run("ACF_UpdateRoundData", self, ToolData, Data, GUIData)
 


### PR DESCRIPTION
Made APHE have scaling penetration, ranging between AP to HE, based on explosive filler ratio
If the filler ratio is 0, it functions identically to AP (X amount of penetration)
Otherwise if it is 1 (100%), it functions identically to HE (0mm pen)
Anywhere between it will function accordingly, as an AP shell with some explosive filler