### PR TITLE
Fix drawing unwanted renderables in PostDrawOpaqueRenderables

### DIFF
--- a/lua/acf/damage/damage_cl.lua
+++ b/lua/acf/damage/damage_cl.lua
@@ -13,7 +13,8 @@ local Materials = {
 	})
 }
 
-local function RenderDamage()
+local function RenderDamage(bDrawingDepth, bDrawingSkybox)
+	if bDrawingDepth or bDrawingSkybox then return end
 	cam.Start3D(EyePos(), EyeAngles())
 
 	for Entity in pairs(Damaged) do

--- a/lua/entities/acf_ammo/cl_init.lua
+++ b/lua/entities/acf_ammo/cl_init.lua
@@ -109,7 +109,8 @@ do -- Resupply effect
 	local Yellow   = Color(255, 255, 0, 10)
 	local Distance = ACF.RefillDistance
 
-	local function DrawSpheres()
+	local function DrawSpheres(bDrawingDepth, bDrawingSkybox)
+		if bDrawingDepth or bDrawingSkybox then return end
 		render.SetColorMaterial()
 
 		for Entity in pairs(Refills) do

--- a/lua/weapons/gmod_tool/stools/acfarmorprop.lua
+++ b/lua/weapons/gmod_tool/stools/acfarmorprop.lua
@@ -280,7 +280,8 @@ if CLIENT then
 	local GreenSphere = Color(0, 200, 0, 50)
 	local GreenFrame = Color(0, 200, 0, 100)
 
-	hook.Add("PostDrawOpaqueRenderables", "Armor Tool Search Sphere", function()
+	hook.Add("PostDrawOpaqueRenderables", "Armor Tool Search Sphere", function(bDrawingDepth, bDrawingSkybox)
+		if bDrawingDepth or bDrawingSkybox then return end
 		local Player = LocalPlayer()
 		local Weapon = Player:GetActiveWeapon()
 		if not IsValid( Weapon ) then return end


### PR DESCRIPTION
In PostDrawOpaqueRenderables hooks, return if the current iteration is drawing depth or the skybox.
This fixes drawing entity damage effect in the skybox on some maps where the 3d skybox isn't far enough from the playable area. Also, fixes refill and armor tool spheres from doing the same thing as shown in the following screenshots.
![wrong](https://github.com/Stooberton/ACF-3/assets/26276775/ad7745cc-ecd1-4cb3-957a-87e3e996410a)
![good](https://github.com/Stooberton/ACF-3/assets/26276775/42c5783a-089b-4b9d-bb19-2323cd6e9204)
