### PR TITLE
Fueltank hotfix

### DIFF
--- a/lua/entities/acf_fueltank/init.lua
+++ b/lua/entities/acf_fueltank/init.lua
@@ -83,7 +83,7 @@ do -- Spawn and Update functions
 		Entity.ACF = Entity.ACF or {}
 		Entity.ACF.Model = FuelTank.Model -- Must be set before changing model
 
-		Entity:SetScaledModel(FuelTank.Model)
+		Entity:SetModel(FuelTank.Model)
 
 		Entity:PhysicsInit(SOLID_VPHYSICS)
 		Entity:SetMoveType(MOVETYPE_VPHYSICS)


### PR DESCRIPTION
Fuel tanks are not scalable and are now causing an error when trying to call this method.