### PR TITLE
Fix the 2d skybox rendering regression, whoops

### DIFF
--- a/lua/acf/damage/damage_cl.lua
+++ b/lua/acf/damage/damage_cl.lua
@@ -13,8 +13,8 @@ local Materials = {
 	})
 }
 
-local function RenderDamage(bDrawingDepth, bDrawingSkybox)
-	if bDrawingDepth or bDrawingSkybox then return end
+local function RenderDamage(bDrawingDepth, _, isDraw3DSkybox)
+	if bDrawingDepth or isDraw3DSkybox then return end
 	cam.Start3D(EyePos(), EyeAngles())
 
 	for Entity in pairs(Damaged) do

--- a/lua/entities/acf_ammo/cl_init.lua
+++ b/lua/entities/acf_ammo/cl_init.lua
@@ -109,8 +109,8 @@ do -- Resupply effect
 	local Yellow   = Color(255, 255, 0, 10)
 	local Distance = ACF.RefillDistance
 
-	local function DrawSpheres(bDrawingDepth, bDrawingSkybox)
-		if bDrawingDepth or bDrawingSkybox then return end
+	local function DrawSpheres(bDrawingDepth, _, isDraw3DSkybox)
+		if bDrawingDepth or isDraw3DSkybox then return end
 		render.SetColorMaterial()
 
 		for Entity in pairs(Refills) do

--- a/lua/weapons/gmod_tool/stools/acfarmorprop.lua
+++ b/lua/weapons/gmod_tool/stools/acfarmorprop.lua
@@ -280,8 +280,8 @@ if CLIENT then
 	local GreenSphere = Color(0, 200, 0, 50)
 	local GreenFrame = Color(0, 200, 0, 100)
 
-	hook.Add("PostDrawOpaqueRenderables", "Armor Tool Search Sphere", function(bDrawingDepth, bDrawingSkybox)
-		if bDrawingDepth or bDrawingSkybox then return end
+	hook.Add("PostDrawOpaqueRenderables", "Armor Tool Search Sphere", function(bDrawingDepth, _, isDraw3DSkybox)
+		if bDrawingDepth or isDraw3DSkybox then return end
 		local Player = LocalPlayer()
 		local Weapon = Player:GetActiveWeapon()
 		if not IsValid( Weapon ) then return end


### PR DESCRIPTION
My recent pull request fixing duplicate draws on the skybox introduced a regression - if r_3dsky was set to 0, damage would not get drawn at all. Apparently, if that is the case bDrawingSkybox was always being set to true. Weird.
Anyway, as it turns out that's why the third argument in that hook exists, which has the behavior we are actually looking for.