### PR TITLE
Remove missing bumpmap from FAB250 material

### DIFF
--- a/materials/models/missiles/fab250.vmt
+++ b/materials/models/missiles/fab250.vmt
@@ -2,7 +2,7 @@
 {
 	"$basetexture" "models/missiles/FAB250"
 	"$surfaceprop" "metal"
-	"$bumpmap" "models/missiles/GBU12_bump"
+	//"$bumpmap" "models/missiles/GBU12_bump"
 	
 	//"$envmapmask" "Models/props_combine/combine_binocular01_mask"
 	//"$selfillum" 0


### PR DESCRIPTION
models/missiles/GBU12_bump is missing. Removed it from the FAB250 material.