### PR TITLE
Proportional Ammo Spacing

### DIFF
--- a/lua/acf/core/globals.lua
+++ b/lua/acf/core/globals.lua
@@ -69,7 +69,7 @@ do -- ACF global vars
 
 	-- Ammo
 	ACF.AmmoArmor          = 5 -- How many millimeters of armor ammo crates have
-	ACF.AmmoPadding        = 10 -- Millimeters of wasted space between rounds
+	ACF.AmmoPadding        = 0.3 -- Ratio of wasted space to projectile case diameter
 	ACF.AmmoCaseScale      = 1 -- How much larger the diameter of the case is versus the projectile (necked cartridges, M829 is 1.4, .50 BMG is 1.6)
 	ACF.AmmoMinSize        = 6 -- Defines the shortest possible length of ammo crates for all their axises, in gmu
 	ACF.AmmoMaxSize        = 96 -- Defines the highest possible length of ammo crates for all their axises, in gmu

--- a/lua/acf/core/round_functions.lua
+++ b/lua/acf/core/round_functions.lua
@@ -310,7 +310,7 @@ do -- Ammo crate capacity calculation
 		local Width     = Caliber * ACF.AmmoCaseScale * 0.1 -- mm to cm
 		local Length    = BulletData.PropLength + BulletData.ProjLength + BulletData.Tracer
 		local MagSize   = math.floor(ACF.GetWeaponValue("MagSize", Caliber, WeaponClass, Weapon) or 1)
-		local Spacing   = math.max(0, ToolData.AmmoPadding or ACF.AmmoPadding) * 0.1 + 0.125
+		local Spacing   = math.max(0, ToolData.AmmoPadding or ACF.AmmoPadding) * Width * 0.1 + 0.125
 		local IsBoxed   = WeaponClass.IsBoxed
 		local Rounds    = 0
 		local ExtraData = {}


### PR DESCRIPTION
- Changes the spacing between shells in ammo crates to be proportional to the diameter of the shells.
- AmmoPadding ratio can be changed if it is determined that the space between each shell is too small or too large.

Before:
![image](https://github.com/Stooberton/ACF-3/assets/72367202/0a8203a2-37ca-465a-9ba4-844c97da6c68)

After:
![image](https://github.com/Stooberton/ACF-3/assets/72367202/8df821a3-8da3-40ac-a0a1-d29928fd4343)


