### PR TITLE
Add legality checks for seats

### DIFF
--- a/lua/acf/contraption/seats_sv.lua
+++ b/lua/acf/contraption/seats_sv.lua
@@ -27,7 +27,7 @@ hook.Add("OnEntityCreated", "ACF_SeatLegality", function(Entity)
             if not IsValid(Driver) then return end
             Driver:ExitVehicle()
         end
-        PrintTable(Entity:GetTable())
+
         if not ACF.VehicleLegalChecks then return end
 
         ACF.CheckLegal(Entity)

--- a/lua/acf/contraption/seats_sv.lua
+++ b/lua/acf/contraption/seats_sv.lua
@@ -1,0 +1,44 @@
+-- Optional functionality for legality checking on all vehicles
+
+hook.Add("OnEntityCreated", "ACF_SeatLegality", function(Entity)
+    timer.Simple(0, function()
+        if not IsValid(Entity) then return end
+        if Entity:GetClass() ~= "prop_vehicle_prisoner_pod" then return end
+        if Entity.fphysSeat then return end -- simfphys vehicles will make non-solid seats that should be ignored
+
+        local PhysObj = Entity:GetPhysicsObject()
+        if not IsValid(PhysObj) then return end
+
+        Entity.ACF = {}
+        Entity.ACF.PhysObj = PhysObj
+        Entity.ACF.LegalMass = PhysObj:GetMass()
+        Entity.ACF.Model = Entity:GetModel()
+        Entity.ACF.LegalSeat = true
+        Entity.WireDebugName = Entity.WireDebugName or (Entity.VehicleTable and Entity.VehicleTable.Name) or "ACF Legal Vehicle"
+
+        Entity.Enable = function()
+            Entity.ACF.LegalSeat = true
+        end
+
+        Entity.Disable = function()
+            Entity.ACF.LegalSeat = false
+
+            local Driver = Entity:GetDriver()
+            if not IsValid(Driver) then return end
+            Driver:ExitVehicle()
+        end
+        PrintTable(Entity:GetTable())
+        if not ACF.VehicleLegalChecks then return end
+
+        ACF.CheckLegal(Entity)
+    end)
+end)
+
+hook.Add("CanPlayerEnterVehicle", "ACF_SeatLegality", function(Player, Entity)
+    if not Entity.ACF then return end
+
+    if not Entity.ACF.LegalSeat then
+        ACF.SendNotify(Player, false, "Seat is not legal and is currently disabled.")
+        return false
+    end
+end)

--- a/lua/acf/core/globals.lua
+++ b/lua/acf/core/globals.lua
@@ -10,6 +10,7 @@ do -- ACF global vars
 
 	-- General Settings
 	ACF.LegalChecks        = true -- Whether or not IsLegal checks should be run on ACF entities
+	ACF.VehicleLegalChecks = true -- Whether or not IsLegal checks should be run on vehicle entities
 	ACF.Year               = 1945
 	ACF.IllegalDisableTime = 30 -- Time in seconds for an entity to be disabled when it fails ACF.IsLegal
 	ACF.RestrictInfo       = true -- If enabled, players will be only allowed to get info from entities they're allowed to mess with.

--- a/lua/acf/menu/data_callbacks.lua
+++ b/lua/acf/menu/data_callbacks.lua
@@ -37,7 +37,18 @@ local Settings = {
 
 		if CLIENT and not IsValid(Player) then return end
 
-		Message("Info", "Legality checks have been " .. (Bool and "enabled." or "disabled."))
+		Message("Info", "Legality checks for ACF entities have been " .. (Bool and "enabled." or "disabled."))
+	end,
+	VehicleLegalChecks = function(Player, _, Value)
+		local Bool = tobool(Value)
+
+		if ACF.VehicleLegalChecks == Bool then return end
+
+		ACF.VehicleLegalChecks = Bool
+
+		if CLIENT and not IsValid(Player) then return end
+
+		Message("Info", "Legality checks for vehicles have been " .. (Bool and "enabled." or "disabled."))
 	end,
 	GunsCanFire = function(Player, _, Value)
 		local Bool = tobool(Value)

--- a/lua/acf/menu/items_cl/settings.lua
+++ b/lua/acf/menu/items_cl/settings.lua
@@ -139,6 +139,14 @@ do -- Serverside settings
 			return Value
 		end)
 
+		local VehicleLegalChecks = Base:AddCheckBox("Enable legality checks on vehicle entities.")
+		VehicleLegalChecks:SetServerData("VehicleLegalChecks", "OnChange")
+		VehicleLegalChecks:DefineSetter(function(Panel, _, _, Value)
+			Panel:SetValue(Value)
+
+			return Value
+		end)
+
 		local GunFire = Base:AddCheckBox("Allow guns to fire.")
 		GunFire:SetServerData("GunsCanFire", "OnChange")
 		GunFire:DefineSetter(function(Panel, _, _, Value)

--- a/lua/acf/persisted_vars/vars_sv.lua
+++ b/lua/acf/persisted_vars/vars_sv.lua
@@ -2,6 +2,7 @@
 
 -- Settings
 ACF.PersistServerData("LegalChecks", true)
+ACF.PersistServerData("VehicleLegalChecks", true)
 ACF.PersistServerData("ServerDataAllowAdmin", false)
 ACF.PersistServerData("RestrictInfo", true)
 ACF.PersistServerData("GunsCanFire", true)


### PR DESCRIPTION
Closes #310

This adds a new serverside setting to allow pod entities to be subject to the same legality checks as ACF entities. I'm making this a PR instead of just committing right away because I'm hoping to get some feedback on this particular implementation; I'm not sure if it's worth trying to give seats their own info overlay as well or not.