### PR TITLE
Fix null particle reference

### DIFF
--- a/lua/acf/damage/damage_cl.lua
+++ b/lua/acf/damage/damage_cl.lua
@@ -121,8 +121,8 @@ do -- Debris Effects ------------------------
 			Entity:StopAndDestroyParticles()
 		end)
 
-		if Smoke then Smoke:StopEmission() end
-		if Ember then Ember:StopEmission() end
+		if IsValid(Smoke) then Smoke:StopEmission() end
+		if IsValid(Ember) then Ember:StopEmission() end
 
 		timer.Simple(5, function()
 			if not IsValid(Entity) then return end


### PR DESCRIPTION
Getting a few stray errors about `Smoke` being a `NULL CNewParticleEffect`:
```
Tried to use a NULL CNewParticleEffect!
1.  StopEmission - [C]:-1
 2.  FadeAway - addons/acf-3/lua/acf/damage/damage_cl.lua:124
  3.  unknown - addons/acf-3/lua/acf/damage/damage_cl.lua:189
```

I don't understand how or why it becomes invalid, so I can't determine if this is a _good_ fix, but it would definitely work 😅 