### PR TITLE
Fix disabling godmode upon removing baseplate

### DIFF
--- a/lua/entities/acf_baseplate/init.lua
+++ b/lua/entities/acf_baseplate/init.lua
@@ -91,8 +91,8 @@ local function ConfigureLuaSeat(Entity, Pod, Player)
 		hook.Remove("PlayerLeaveVehicle", "ACFBaseplateSeatExit" .. Entity:EntIndex())
 		hook.Remove("PlayerUse", "ACFBaseplateSeatEnterExternal" .. Entity:EntIndex())
 
-		local Owner = Entity:CPPIGetOwner()
-		if IsValid(Owner) then Owner:GodDisable() end
+		--local Owner = Entity:CPPIGetOwner()
+		--if IsValid(Owner) then Owner:GodDisable() end
 
 		SafeRemoveEntity(Ent.Pod)
 


### PR DESCRIPTION
I couldn't find anything not commented out in code that enabled god mode, so why disable it upon deleting a baseplate?