### PR TITLE
Move entity definitions to be less repetitive

### DIFF
--- a/lua/entities/acf_base_scalable/cl_init.lua
+++ b/lua/entities/acf_base_scalable/cl_init.lua
@@ -1,3 +1,3 @@
 DEFINE_BASECLASS("base_scalable") -- Required to get the local BaseClass
 include("shared.lua")
-include("entities/acf_base_simple/modules/cl.lua")
+include("entities/acf_base_simple/modules/cl.lua")(BaseClass)

--- a/lua/entities/acf_base_scalable/init.lua
+++ b/lua/entities/acf_base_scalable/init.lua
@@ -3,4 +3,4 @@ AddCSLuaFile("shared.lua")
 
 include("shared.lua")
 AddCSLuaFile("entities/acf_base_simple/modules/cl.lua")
-include("entities/acf_base_simple/modules/sv.lua")
+include("entities/acf_base_simple/modules/sv.lua")()

--- a/lua/entities/acf_base_simple/cl_init.lua
+++ b/lua/entities/acf_base_simple/cl_init.lua
@@ -1,3 +1,3 @@
 DEFINE_BASECLASS("base_wire_entity") -- Required to get the local BaseClass
 include("shared.lua")
-include("entities/acf_base_simple/modules/cl.lua")
+include("entities/acf_base_simple/modules/cl.lua")(BaseClass)

--- a/lua/entities/acf_base_simple/init.lua
+++ b/lua/entities/acf_base_simple/init.lua
@@ -3,4 +3,4 @@ AddCSLuaFile("shared.lua")
 
 include("shared.lua")
 AddCSLuaFile("entities/acf_base_simple/modules/cl.lua")
-include("entities/acf_base_simple/modules/sv.lua")
+include("entities/acf_base_simple/modules/sv.lua")()

--- a/lua/entities/acf_base_simple/modules/cl.lua
+++ b/lua/entities/acf_base_simple/modules/cl.lua
@@ -1,29 +1,31 @@
-local HideInfo = ACF.HideInfoBubble
-local WireRender = Wire_Render
+return function(BaseClass)
+    local HideInfo = ACF.HideInfoBubble
+    local WireRender = Wire_Render
 
-function ENT:Initialize(...)
-	BaseClass.Initialize(self, ...)
+    function ENT:Initialize(...)
+        BaseClass.Initialize(self, ...)
 
-	self:Update()
-end
-function ENT:Update() end
+        self:Update()
+    end
+    function ENT:Update() end
 
-local ENTITY = FindMetaTable("Entity")
--- Copied from base_wire_entity: DoNormalDraw's notip arg isn't accessible from ENT:Draw defined there.
-function ENT:Draw()
-	local HaloTip = not HideInfo()
+    local ENTITY = FindMetaTable("Entity")
+    -- Copied from base_wire_entity: DoNormalDraw's notip arg isn't accessible from ENT:Draw defined there.
+    function ENT:Draw()
+        local HaloTip = not HideInfo()
 
-	local RenderContext = ACF.RenderContext
-	local LookedAt = RenderContext.LookAt == self
+        local RenderContext = ACF.RenderContext
+        local LookedAt = RenderContext.LookAt == self
 
-	if HaloTip and LookedAt then
-		if RenderContext.ShouldDrawOutline then
-			self:DrawEntityOutline()
-		end
-		ENTITY.DrawModel(self)
-	else
-		ENTITY.DrawModel(self)
-	end
+        if HaloTip and LookedAt then
+            if RenderContext.ShouldDrawOutline then
+                self:DrawEntityOutline()
+            end
+            ENTITY.DrawModel(self)
+        else
+            ENTITY.DrawModel(self)
+        end
 
-	WireRender(self)
+        WireRender(self)
+    end
 end

--- a/lua/entities/acf_base_simple/modules/sv.lua
+++ b/lua/entities/acf_base_simple/modules/sv.lua
@@ -1,165 +1,166 @@
+return function()
+    local ACF = ACF
 
-local ACF = ACF
+    ENT.OverlayDelay = 1 -- Time in seconds between each overlay update
 
-ENT.OverlayDelay = 1 -- Time in seconds between each overlay update
+    -- You should overwrite these
+    function ENT:Enable() end
+    function ENT:Disable() end
+    function ENT:ACF_UpdateOverlayState() end
 
--- You should overwrite these
-function ENT:Enable() end
-function ENT:Disable() end
-function ENT:ACF_UpdateOverlayState() end
+    do -- Entity Overlay ----------------------------
+        local Name    = "ACF Overlay Buffer %s"
+        local timer   = timer
 
-do -- Entity Overlay ----------------------------
-	local Name    = "ACF Overlay Buffer %s"
-	local timer   = timer
+        function ENT:GetOverlayState()
+            local OverlayState = self.OverlayState
+            if not OverlayState then
+                OverlayState = ACF.Overlay.State()
+                self.OverlayState = OverlayState
+                self:UpdateOverlay(true)
+            end
 
-	function ENT:GetOverlayState()
-		local OverlayState = self.OverlayState
-		if not OverlayState then
-			OverlayState = ACF.Overlay.State()
-			self.OverlayState = OverlayState
-			self:UpdateOverlay(true)
-		end
+            return OverlayState
+        end
 
-		return OverlayState
-	end
+        local function DoUpdate(self, OverlayState)
+            OverlayState:Begin()
+            local WireName = self:GetNWString("WireName")
+            OverlayState:AddHeader(#WireName == 0 and self.PrintName or WireName)
+            self:ACF_UpdateOverlayState(OverlayState)
+            OverlayState:End()
+            ACF.Overlay.UpdateOverlay(self, OverlayState)
+        end
+        function ENT:UpdateOverlay(Instant)
+            local OverlayState = self.OverlayState
+            if not OverlayState then
+                OverlayState = ACF.Overlay.State()
+                self.OverlayState = OverlayState
+            end
 
-	local function DoUpdate(self, OverlayState)
-		OverlayState:Begin()
-		local WireName = self:GetNWString("WireName")
-		OverlayState:AddHeader(#WireName == 0 and self.PrintName or WireName)
-		self:ACF_UpdateOverlayState(OverlayState)
-		OverlayState:End()
-		ACF.Overlay.UpdateOverlay(self, OverlayState)
-	end
-	function ENT:UpdateOverlay(Instant)
-		local OverlayState = self.OverlayState
-		if not OverlayState then
-			OverlayState = ACF.Overlay.State()
-			self.OverlayState = OverlayState
-		end
+            if Instant then
+                DoUpdate(self, OverlayState)
+                return
+            end
 
-		if Instant then
-			DoUpdate(self, OverlayState)
-			return
-		end
+            if self.OverlayCooldown then -- This entity has been updated too recently
+                self.QueueOverlay = true -- Mark it to update when buffer time has expired
+            else
+                DoUpdate(self, OverlayState)
 
-		if self.OverlayCooldown then -- This entity has been updated too recently
-			self.QueueOverlay = true -- Mark it to update when buffer time has expired
-		else
-			DoUpdate(self, OverlayState)
+                self.OverlayCooldown = true
 
-			self.OverlayCooldown = true
+                timer.Create(Name:format(self:EntIndex()), self.OverlayDelay, 1, function()
+                    if not IsValid(self) then return end
 
-			timer.Create(Name:format(self:EntIndex()), self.OverlayDelay, 1, function()
-				if not IsValid(self) then return end
+                    self.OverlayCooldown = nil
 
-				self.OverlayCooldown = nil
+                    if self.QueueOverlay then
+                        self.QueueOverlay = nil
 
-				if self.QueueOverlay then
-					self.QueueOverlay = nil
+                        self:UpdateOverlay(false)
+                    end
+                end)
+            end
+        end
+    end ---------------------------------------------
 
-					self:UpdateOverlay(false)
-				end
-			end)
-		end
-	end
-end ---------------------------------------------
+    do -- Entity linking and unlinking --------------
+        function ENT:Link(Target, FromChip)
+            return ACF.PerformClassLink(self, Target, FromChip)
+        end
 
-do -- Entity linking and unlinking --------------
-	function ENT:Link(Target, FromChip)
-		return ACF.PerformClassLink(self, Target, FromChip)
-	end
+        function ENT:Unlink(Target)
+            return ACF.PerformClassUnlink(self, Target)
+        end
+    end ---------------------------------------------
 
-	function ENT:Unlink(Target)
-		return ACF.PerformClassUnlink(self, Target)
-	end
-end ---------------------------------------------
+    do -- Entity inputs -----------------------------
+        local function SetupInputActions(Entity)
+            Entity.InputActions = ACF.GetInputActions(Entity:GetClass())
+        end
 
-do -- Entity inputs -----------------------------
-	local function SetupInputActions(Entity)
-		Entity.InputActions = ACF.GetInputActions(Entity:GetClass())
-	end
+        local function FindInputName(Entity, Name, Actions)
+            if not Entity.InputAliases then return Name end
 
-	local function FindInputName(Entity, Name, Actions)
-		if not Entity.InputAliases then return Name end
+            local Aliases = Entity.InputAliases
+            local Checked = { [Name] = true }
 
-		local Aliases = Entity.InputAliases
-		local Checked = { [Name] = true }
+            repeat
+                if Actions[Name] then
+                    return Name
+                end
 
-		repeat
-			if Actions[Name] then
-				return Name
-			end
+                Checked[Name] = true
 
-			Checked[Name] = true
-
-			Name = Aliases[Name] or Name
-		until
-			Checked[Name]
+                Name = Aliases[Name] or Name
+            until
+                Checked[Name]
 
 
-		return Name
-	end
+            return Name
+        end
 
-	function ENT:TriggerInput(Name, Value)
-		if self.Disabled then return end -- Ignore input if disabled
-		if not self.InputActions then SetupInputActions(self) end
+        function ENT:TriggerInput(Name, Value)
+            if self.Disabled then return end -- Ignore input if disabled
+            if not self.InputActions then SetupInputActions(self) end
 
-		local Actions  = self.InputActions
-		local RealName = FindInputName(self, Name, Actions)
-		local Action   = Actions[RealName]
+            local Actions  = self.InputActions
+            local RealName = FindInputName(self, Name, Actions)
+            local Action   = Actions[RealName]
 
-		if Action then
-			Action(self, Value)
+            if Action then
+                Action(self, Value)
 
-			self:UpdateOverlay()
-		end
-	end
-end ---------------------------------------------
+                self:UpdateOverlay()
+            end
+        end
+    end ---------------------------------------------
 
-do -- Entity user -------------------------------
-	-- TODO: Add a function to register more user sources
-	local WireTable = {
-		gmod_wire_adv_pod = true,
-		gmod_wire_joystick = true,
-		gmod_wire_expression2 = true,
-		gmod_wire_joystick_multi = true,
-		gmod_wire_pod = function(_, Input)
-			if IsValid(Input.Pod) then
-				return Input.Pod:GetDriver()
-			end
-		end,
-		gmod_wire_keyboard = function(_, Input)
-			if Input.ply then
-				return Input.ply
-			end
-		end,
-	}
+    do -- Entity user -------------------------------
+        -- TODO: Add a function to register more user sources
+        local WireTable = {
+            gmod_wire_adv_pod = true,
+            gmod_wire_joystick = true,
+            gmod_wire_expression2 = true,
+            gmod_wire_joystick_multi = true,
+            gmod_wire_pod = function(_, Input)
+                if IsValid(Input.Pod) then
+                    return Input.Pod:GetDriver()
+                end
+            end,
+            gmod_wire_keyboard = function(_, Input)
+                if Input.ply then
+                    return Input.ply
+                end
+            end,
+        }
 
-	local function FindUser(Entity, Input, Checked)
-		local Function = WireTable[Input:GetClass()]
+        local function FindUser(Entity, Input, Checked)
+            local Function = WireTable[Input:GetClass()]
 
-		return Function and Function(Entity, Input, Checked or {})
-	end
+            return Function and Function(Entity, Input, Checked or {})
+        end
 
-	WireTable.gmod_wire_adv_pod			= WireTable.gmod_wire_pod
-	WireTable.gmod_wire_joystick		= WireTable.gmod_wire_pod
-	WireTable.gmod_wire_joystick_multi	= WireTable.gmod_wire_pod
-	WireTable.gmod_wire_expression2		= function(This, Input, Checked)
-		for _, V in pairs(Input.Inputs) do
-			if IsValid(V.Src) and not Checked[V.Src] and WireTable[V.Src:GetClass()] then
-				Checked[V.Src] = true -- We don't want to start an infinite loop
+        WireTable.gmod_wire_adv_pod			= WireTable.gmod_wire_pod
+        WireTable.gmod_wire_joystick		= WireTable.gmod_wire_pod
+        WireTable.gmod_wire_joystick_multi	= WireTable.gmod_wire_pod
+        WireTable.gmod_wire_expression2		= function(This, Input, Checked)
+            for _, V in pairs(Input.Inputs) do
+                if IsValid(V.Src) and not Checked[V.Src] and WireTable[V.Src:GetClass()] then
+                    Checked[V.Src] = true -- We don't want to start an infinite loop
 
-				return FindUser(This, V.Src, Checked)
-			end
-		end
-	end
+                    return FindUser(This, V.Src, Checked)
+                end
+            end
+        end
 
-	function ENT:GetUser(Input)
-		if not IsValid(Input) then return self:GetPlayer() end
+        function ENT:GetUser(Input)
+            if not IsValid(Input) then return self:GetPlayer() end
 
-		local User = FindUser(self, Input)
+            local User = FindUser(self, Input)
 
-		return IsValid(User) and User or self:GetPlayer()
-	end
-end ---------------------------------------------
+            return IsValid(User) and User or self:GetPlayer()
+        end
+    end ---------------------------------------------
+end


### PR DESCRIPTION
This moves cl_init.lua + init.lua in both acf_base_simple and acf_base_scalable to their own file. Both of those files are pretty much exact duplicates of each other, minus one line in cl_init, which I took into account.