### PR TITLE
Fix typo in Replace Other keyvalue that would return nil

### DIFF
--- a/lua/entities/acf_crew/init.lua
+++ b/lua/entities/acf_crew/init.lua
@@ -621,7 +621,7 @@ do
 		State:AddNumber("Move", math.Round(self.MoveEff * 100, 2), "%")
 		State:AddNumber("Focus", math.Round(self.Focus * 100, 2), "%")
 		State:AddNumber("Total", math.Round(self.TotalEff * 100, 2), "%")
-		State:AddKeyValue("Replaces Others", self.ReplacesOthers and "Yes" or "No")
+		State:AddKeyValue("Replaces Others", self.ReplaceOthers and "Yes" or "No")
 		State:AddKeyValue("Replaceable", self.ReplaceSelf and "Yes" or "No")
 		State:AddNumber("Priority", self.CrewPriority)
 	end


### PR DESCRIPTION
The key-value in acf_crew for replacing other crewmembers is being stored as self.ReplaceOthers, but added as a key-value under self.ReplacesOthers, returning inaccurate results to the HUD.