### PR TITLE
Baseplate repulsion improvements

### DIFF
--- a/lua/acf/contraption/track_contraption_players_sv.lua
+++ b/lua/acf/contraption/track_contraption_players_sv.lua
@@ -19,6 +19,10 @@ hook.Add("cfw.contraption.created", "ACF_CFW_TrackPlayersInContraptions", functi
     Contraption.ACF_TrackPlayers = {}
 end)
 
+function ACF.DoesContraptionHavePlayers(Contraption)
+    return Contraption.ACF_TrackPlayers ~= nil and next(Contraption.ACF_TrackPlayers) ~= nil
+end
+
 local PlayersCopy = {}
 hook.Add("cfw.contraption.split", "ACF_CFW_TrackPlayersInContraptions", function(ParentContraption, ChildContraption)
     ParentContraption.ACF_TrackPlayers = ParentContraption.ACF_TrackPlayers or {}

--- a/lua/entities/acf_baseplate/modules/repulsion.lua
+++ b/lua/entities/acf_baseplate/modules/repulsion.lua
@@ -53,6 +53,8 @@ hook.Add("Think", "ACF_Baseplate_Collision_Simulation", function()
 			if not Valid1 or not Valid2 then continue end
 			if Contraption1 == Contraption2 then continue end
 
+			if not ACF.DoesContraptionHavePlayers(Contraption1) or not ACF.DoesContraptionHavePlayers(Contraption2) then continue end
+
 			local IntersectionDistance, IntersectionDirection, IntersectionCenter = CalculateSphereIntersection(Pos1, Radius1, Pos2, Radius2)
 
 			if IntersectionDistance > 0 then continue end

--- a/lua/entities/acf_baseplate/modules/repulsion.lua
+++ b/lua/entities/acf_baseplate/modules/repulsion.lua
@@ -82,6 +82,8 @@ hook.Add("Think", "ACF_Baseplate_Collision_Simulation", function()
 			if not Valid1 or not Valid2 then continue end
 			if Contraption1 == Contraption2 then continue end
 
+			if not ACF.DoesContraptionHavePlayers(Contraption1) or not ACF.DoesContraptionHavePlayers(Contraption2) then continue end
+
 			local SphereIntersectionDistance, IntersectionDirection, IntersectionCenter = CalculateSphereIntersection(Pos1, Radius1, Pos2, Radius2)
 
 			if SphereIntersectionDistance > 0 then continue end

--- a/lua/entities/acf_baseplate/modules/repulsion.lua
+++ b/lua/entities/acf_baseplate/modules/repulsion.lua
@@ -51,7 +51,7 @@ end
 
 local function CalculateBoxIntersection(Mins1, Maxs1, Mins2, Maxs2)
 	if not util.IsBoxIntersectingBox(Mins1, Maxs1, Mins2, Maxs2) then return false end
-	
+
 	local min1x, min1y, min1z = Mins1:Unpack()
 	local max1x, max1y, max1z = Maxs1:Unpack()
 	local min2x, min2y, min2z = Mins2:Unpack()

--- a/lua/entities/acf_baseplate/modules/repulsion.lua
+++ b/lua/entities/acf_baseplate/modules/repulsion.lua
@@ -1,29 +1,43 @@
 local ACF      		= ACF
 
-local function GetBaseplateProperties(Ent, Self, SelfPos, SelfRadius)
-	if Ent == Self then return false end
+local function BaseplateRepulsionCheck(Ent)
+	if IsValid(Ent:GetParent()) then return true end
+	return ACF.IsEntityEligiblePhysmass(Ent)
+end
 
+local function GetBaseplateProperties(Ent)
 	if not IsValid(Ent) then return false end
 	if Ent:GetClass() ~= "acf_baseplate" then return false end
-	if not Ent.Size then return false end
 	if Ent:IsPlayerHolding() then return false end
 
 	local Physics     = Ent:GetPhysicsObject()
 	if not IsValid(Physics) then return false end
 
-	local Pos         = Physics:GetPos()
-	local Radius      = math.sqrt((Ent.Size[1] / 2) ^ 2 + (Ent.Size[2] / 2) ^ 2)
+	local Contraption = Ent:GetContraption()
+	if not Contraption then return end
 
-	if Self and not util.IsSphereIntersectingSphere(SelfPos, SelfRadius, Pos, Radius) then
-		return false
+	local Now = CurTime()
+	-- This is kinda disgusting to read
+	-- The AABB should be cached off and only repopulated every now and then.
+	-- Getting it every tick would be way too expensive.
+	-- To reduce exploit potential, the repolling rate for this cached data is randomized.
+	if not Ent.ACF_CacheBaseplateData then Ent.ACF_CacheBaseplateData = {} end
+	local ACF_CacheBaseplateData = Ent.ACF_CacheBaseplateData
+	if not ACF_CacheBaseplateData.LastTime or (Now - ACF_CacheBaseplateData.LastTime) > math.Rand(0.2, 0.5) then
+		ACF_CacheBaseplateData.Mins, ACF_CacheBaseplateData.Maxs, ACF_CacheBaseplateData.Center = Contraption:GetAABB(BaseplateRepulsionCheck)
+		ACF_CacheBaseplateData.LastTime = Now
 	end
 
-	local Vel         = Physics:GetVelocity()
-	local Contraption = Ent:GetContraption()
-	local PhysMass    = Physics:GetMass()
-	local TotalMass	  = Contraption and Contraption.totalMass or PhysMass
+	local Mins, Maxs, Center = ACF_CacheBaseplateData.Mins, ACF_CacheBaseplateData.Maxs, ACF_CacheBaseplateData.Center
+	-- debugoverlay.Box(Center, Mins - Center, Maxs - Center, 0.1, Color(155, 155, 155, 50))
+	local Pos         = Physics:GetPos()
+	local Radius      = Maxs:Distance(Mins) / 2
 
-	return true, Physics, Pos, Vel, Contraption, PhysMass, TotalMass, Radius
+	local Vel         = Physics:GetVelocity()
+	local PhysMass    = Physics:GetMass()
+	local TotalMass	  = Contraption.totalMass
+
+	return true, Physics, Mins, Maxs, Center, Pos, Vel, Contraption, PhysMass, TotalMass, Radius
 end
 
 local function CalculateSphereIntersection(Pos1, Radius1, Pos2, Radius2)
@@ -33,6 +47,21 @@ local function CalculateSphereIntersection(Pos1, Radius1, Pos2, Radius2)
 
 	local Intersection = Dist - Radius1 - Radius2
 	return Intersection, Dir, (Pos1 * Radius1 + Pos2 * Radius2) / (Radius1 + Radius2)
+end
+
+local function CalculateBoxIntersection(Mins1, Maxs1, Mins2, Maxs2)
+	if not util.IsBoxIntersectingBox(Mins1, Maxs1, Mins2, Maxs2) then return false end
+	
+	local min1x, min1y, min1z = Mins1:Unpack()
+	local max1x, max1y, max1z = Maxs1:Unpack()
+	local min2x, min2y, min2z = Mins2:Unpack()
+	local max2x, max2y, max2z = Maxs2:Unpack()
+
+	local ix = math.min(max1x, max2x) - math.max(min1x, min2x)
+	local iy = math.min(max1y, max2y) - math.max(min1y, min2y)
+	local iz = math.min(max1z, max2z) - math.max(min1z, min2z)
+
+	return true, math.min(ix, iy, iz)
 end
 
 hook.Add("Think", "ACF_Baseplate_Collision_Simulation", function()
@@ -47,17 +76,20 @@ hook.Add("Think", "ACF_Baseplate_Collision_Simulation", function()
 			if not BP1.Size or not BP2.Size then continue end
 			if BP1:IsPlayerHolding() or BP2:IsPlayerHolding() then continue end
 
-			local Valid1, Physics1, Pos1, Vel1, Contraption1, PhysMass1, TotalMass1, Radius1 = GetBaseplateProperties(BP1)
-			local Valid2, Physics2, Pos2, Vel2, Contraption2, PhysMass2, TotalMass2, Radius2 = GetBaseplateProperties(BP2)
+			local Valid1, Physics1, Mins1, Maxs1, _, Pos1, Vel1, Contraption1, PhysMass1, TotalMass1, Radius1 = GetBaseplateProperties(BP1)
+			local Valid2, Physics2, Mins2, Maxs2, _, Pos2, Vel2, Contraption2, PhysMass2, TotalMass2, Radius2 = GetBaseplateProperties(BP2)
 
 			if not Valid1 or not Valid2 then continue end
 			if Contraption1 == Contraption2 then continue end
 
-			if not ACF.DoesContraptionHavePlayers(Contraption1) or not ACF.DoesContraptionHavePlayers(Contraption2) then continue end
+			local SphereIntersectionDistance, IntersectionDirection, IntersectionCenter = CalculateSphereIntersection(Pos1, Radius1, Pos2, Radius2)
 
-			local IntersectionDistance, IntersectionDirection, IntersectionCenter = CalculateSphereIntersection(Pos1, Radius1, Pos2, Radius2)
+			if SphereIntersectionDistance > 0 then continue end
 
-			if IntersectionDistance > 0 then continue end
+			-- Sphere checks are less expensive than box checks, so if the sphere check passes, perform the box check
+			local IsIntersecting, IntersectionDistance = CalculateBoxIntersection(Mins1, Maxs1, Mins2, Maxs2)
+			if not IsIntersecting then continue end
+			IntersectionDistance = -IntersectionDistance
 
 			local CollisionForce1 = ((Vel1 / 4) + ( IntersectionDirection * IntersectionDistance * 150)) * 100
 			local CollisionForce2 = ((Vel2 / 4) + (-IntersectionDirection * IntersectionDistance * 150)) * 100
@@ -77,31 +109,6 @@ hook.Add("Think", "ACF_Baseplate_Collision_Simulation", function()
 		end
 	end
 end)
-
-function ENT:BaseplateRepulsion()
-	if not self.Size then return end
-	if self:IsPlayerHolding() then return end
-	local SelfValid, _, SelfPos, SelfVel, SelfContraption, SelfMass, SelfRadius = GetBaseplateProperties(self)
-	if not SelfValid then return end
-
-	for Victim in pairs(ACF.ActiveBaseplatesTable) do
-		local VictimValid, VictimPhysics, VictimPos, _, VictimContraption, VictimMass, VictimRadius = GetBaseplateProperties(Victim, self, SelfPos, SelfRadius)
-		if not VictimValid then continue end
-
-		-- This is already blocked by the CFW detour, so this is just in case
-		-- that breaks for whatever reason
-		if SelfContraption == VictimContraption then continue end
-
-		local IntersectionDistance, IntersectionDirection, IntersectionCenter = CalculateSphereIntersection(SelfPos, SelfRadius, VictimPos, VictimRadius)
-		local MassRatio = math.Clamp(SelfMass / VictimMass, 0, .9)
-		local LinImpulse, AngImpulse = VictimPhysics:CalculateForceOffset(((SelfVel / 4) + (-IntersectionDirection * IntersectionDistance * 150)) * MassRatio * 100, IntersectionCenter)
-
-		VictimPhysics:ApplyForceCenter(LinImpulse)
-		VictimPhysics:ApplyTorqueCenter(VictimPhysics:LocalToWorldVector(AngImpulse * 2))
-		self:PlayBaseplateRepulsionSound(SelfVel)
-		Victim:PlayBaseplateRepulsionSound(SelfVel)
-	end
-end
 
 function ENT:PlayBaseplateRepulsionSound(Vel)
 	local Hard = Vel:Length() > 500 and true or false


### PR DESCRIPTION
This does two things:

1. Baseplates can now only repulse other baseplates when a player is in them and they're part of an overall contraption. This tries to mitigate an unintended behavior some people were doing where they'd use baseplates as unkillable hedgehogs.
2. Baseplates now use a box collider instead of a sphere collider. The sphere test is still done for the sake of not running the box test unless it is necessary to do so (sphere check being cheaper to perform I presume).