### PR TITLE
DoubleDifferential Fix

### DIFF
--- a/lua/entities/acf_gearbox/init.lua
+++ b/lua/entities/acf_gearbox/init.lua
@@ -930,9 +930,10 @@ do -- Movement -----------------------------------------
 						end
 					end
 
-					Link.ReqTq = (InputRPM * Multiplier - RPM) * InputInertia * Clutch
-
-					TotalReqTq = TotalReqTq + abs(Link.ReqTq)
+					if abs(InputRPM * Multiplier) > abs(RPM) then -- removing this check causes the wheels to constantly invert their rotation
+						Link.ReqTq = (InputRPM * Multiplier - RPM) * InputInertia * Clutch
+						TotalReqTq = TotalReqTq + abs(Link.ReqTq)
+					end
 				end
 			end
 		end


### PR DESCRIPTION
fixed Output wheels RPM being higher than RPM that the gearbox wants to output causing it to constantly invert the rotation of the wheel

This is probably a very quick and dirty solution but its a solution