### PR TITLE
New notification API

### DIFF
--- a/lua/acf/combat/crew_disable_sv.lua
+++ b/lua/acf/combat/crew_disable_sv.lua
@@ -1,5 +1,6 @@
 -- Purpose: Block crewed contraptions that have had their crew killed from being able to be entered again.
 local ACF = ACF
+local Notify = ACF.Utilities.Notify
 
 hook.Add("CanPlayerEnterVehicle", "ACF_CanPlayerEnterVehicle_BlockEnterVehicleOnDeadContraption", function(Player, Vehicle)
     if not IsValid(Vehicle) then return end
@@ -11,7 +12,13 @@ hook.Add("CanPlayerEnterVehicle", "ACF_CanPlayerEnterVehicle_BlockEnterVehicleOn
 
     if Contraption.ACF_AllCrewKilled then
         if (Now - (Contraption.ACF_LastNotifyDeathTime or 0)) > 1 then
-            ACF.SendNotify(Player, false, "This contraption is no longer usable.")
+            Notify.Start()
+            Notify.WithTitle("This contraption is no longer usable.")
+            Notify.WithSilkIcon("error")
+            Notify.WithTargetEntity(Contraption.ACF_Baseplate)
+            Notify.WithDescription("All crew members have been killed.")
+            Notify.AddPlayer(Player)
+            Notify.Transmit()
             Contraption.ACF_LastNotifyDeathTime = Now
         end
 

--- a/lua/acf/combat/crew_disable_sv.lua
+++ b/lua/acf/combat/crew_disable_sv.lua
@@ -12,13 +12,7 @@ hook.Add("CanPlayerEnterVehicle", "ACF_CanPlayerEnterVehicle_BlockEnterVehicleOn
 
     if Contraption.ACF_AllCrewKilled then
         if (Now - (Contraption.ACF_LastNotifyDeathTime or 0)) > 1 then
-            Notify.Start()
-            Notify.WithTitle("This contraption is no longer usable.")
-            Notify.WithSilkIcon("error")
-            Notify.WithTargetEntity(Contraption.ACF_Baseplate)
-            Notify.WithDescription("All crew members have been killed.")
-            Notify.AddPlayer(Player)
-            Notify.Transmit()
+            Notify.EntityWarningToPlayer(Contraption.ACF_Baseplate, Player, "This contraption is no longer usable.", "All crew members have been killed.")
             Contraption.ACF_LastNotifyDeathTime = Now
         end
 

--- a/lua/acf/compatibility/baseplate_convert_sv.lua
+++ b/lua/acf/compatibility/baseplate_convert_sv.lua
@@ -1,4 +1,5 @@
 local ACF = ACF
+local Notify = ACF.Utilities.Notify
 
 -- permutation is of the form (Axis mapped to X, Axis mapped to Y, Axis mapped to Z). Default is Vector(1, 2, 3) which means X -> X, Y -> Y, Z -> Z.
 -- addAngles is the angles to add to the model angles after the conversion
@@ -140,7 +141,7 @@ function ACF.ConvertBaseplate(Player, Target)
         end
 
         if foundTranslation.warning then
-            ACF.SendNotify(Player, false, foundTranslation.warning)
+            Notify.WarningToPlayer(Player, "An issue occured while converting a prop to an ACF baseplate", foundTranslation.warning)
         end
     elseif BaseplateToProp then
         -- Baseplate to prop conversion

--- a/lua/acf/contraption/seats_sv.lua
+++ b/lua/acf/contraption/seats_sv.lua
@@ -37,6 +37,7 @@ local ValidSeatModels = {
 }
 
 ACF.ValidSeatModels = ValidSeatModels
+local Notify = ACF.Utilities.Notify
 
 hook.Add("OnEntityCreated", "ACF_SeatLegality", function(Entity)
     timer.Simple(0, function()
@@ -94,7 +95,7 @@ hook.Add("CanPlayerEnterVehicle", "ACF_SeatLegality", function(Player, Entity)
 
     Reason = Reason or "Reason not found."
 
-    ACF.SendNotify(Player, false, "[ACF] Seat is not legal and is currently disabled. (" .. Reason .. ")")
+    Notify.EntityWarningToPlayer(Entity, Player, "Seat is not legal and is currently disabled.", Reason)
 
     return false
 end)

--- a/lua/acf/core/utilities/notify/notification_cl.lua
+++ b/lua/acf/core/utilities/notify/notification_cl.lua
@@ -1,0 +1,513 @@
+local Notify = ACF.Utilities.Notify
+local notification = notification
+
+local MAX_BUTTON_BITS = 4
+
+-- This sucks but there's no better way to do it right now.
+local _, Notices = debug.getupvalue(notification.Kill, 1)
+
+function Notify.Display(Data)
+    local Parent = nil
+    if GetOverlayPanel then Parent = GetOverlayPanel() end
+
+    local Panel = vgui.Create("ACF_NoticePanel", Parent)
+    Panel.StartTime = SysTime()
+    Panel.Length = Data.Duration
+    Panel:SetData(Data)
+    Panel.VelX = -5
+    Panel.VelY = 0
+    Panel.fx = ScrW() + 200
+    Panel.fy = ScrH()
+    Panel:SetAlpha(255)
+    Panel:SetPos(Panel.fx, Panel.fy)
+
+    table.insert(Notices, Panel)
+end
+
+do -- Receiving new notifications
+    net.Receive("ACF_Notify", function()
+        local Title = Notify.Net_ReadFormattedText()
+        local Description = Notify.Net_ReadFormattedText()
+        local Duration = net.ReadFloat()
+        local Icon = net.ReadString()
+        local TargetEntityIdx = net.ReadUInt(MAX_EDICT_BITS)
+        local TargetPhysObjIdx = net.ReadInt(10)
+        local ButtonCount = net.ReadUInt(MAX_BUTTON_BITS)
+        local Buttons = {}
+
+        for I = 1, ButtonCount do
+            local Button = {}
+            Button.Text = Notify.Net_ReadFormattedText()
+            Button.Pulsing = net.ReadBool()
+            Button.Action = net.ReadString()
+            Button.Params = {}
+            local NumParams = net.ReadUInt(6)
+            for I2 = 1, NumParams do
+                Button.Params[I2] = net.ReadType()
+            end
+            Buttons[I] = Button
+        end
+
+        -- Use the received data
+        CurrentNotification = {
+            Title = Title,
+            Description = Description,
+            Duration = Duration,
+            Icon = Icon,
+            Buttons = Buttons,
+            TargetEntity = TargetEntityIdx,
+            TargetPhysObj = TargetPhysObjIdx,
+        }
+
+        local TargetEnt = Entity(TargetEntityIdx)
+        if IsValid(TargetEnt) then
+            Notify.SingleEntityImpulse(TargetEnt)
+        end
+
+        Notify.Display(CurrentNotification)
+    end)
+end
+
+surface.CreateFont("ACF_GModNotify_Description", {
+    font	= "Arial",
+    size	= 16,
+    weight	= 0,
+    extended = true
+})
+
+-- Notifications can use these shared helper functions to highlight entities with the halo system
+-- Perhaps we should do our own thing instead of halos, but its abstracted away so we can do that later
+-- if its determined to be worth it
+do
+    local Entities = {}
+    local HoveredEntities = {}
+
+    local TempEntityBufferSustained = {}
+    local HaloColor = Color(210, 222, 255)
+    hook.Add("PreDrawHalos", "ACF_DrawNotificationHolos", function()
+        if #Entities == 0 and #HoveredEntities == 0 then return end
+
+        local DeltaTime = RealFrameTime()
+        local Time      = SysTime()
+        for I = #Entities, 1, -1 do
+            local EntityData = Entities[I]
+            if not IsValid(EntityData.Ent) or EntityData.Time <= 0 then
+                table.remove(Entities, I)
+            else
+                local AnimT = math.ease.InCubic(EntityData.Time)
+                halo.Add({EntityData.Ent}, EntityData.Color, 5 * AnimT, 5 * AnimT, 2, true, true)
+                EntityData.Color.a = 255 * AnimT
+                EntityData.Time = EntityData.Time - DeltaTime
+            end
+        end
+
+        TempEntityBufferSustained[1] = nil
+        local I = 1
+        for Entity in pairs(HoveredEntities) do
+            if IsValid(Entity) then
+                TempEntityBufferSustained[I] = Entity
+            end
+        end
+        TempEntityBufferSustained[I + 1] = nil -- null terminate
+        HaloColor.a = 255 * math.Remap(math.sin(Time * 7), -1, 1, 0.6, 1)
+        halo.Add(TempEntityBufferSustained, HaloColor, 3, 3, 2, true, true)
+        HaloColor.a = 255
+    end)
+
+    function Notify.SingleEntityImpulse(Entity, Color)
+        if not IsValid(Entity) then return end
+        Entities[#Entities + 1] = {
+            Ent = Entity,
+            Color = (Color or HaloColor):Copy(),
+            Time = 1
+        }
+    end
+
+    function Notify.StartEntityPulse(Entity)
+        HoveredEntities[Entity] = true
+    end
+
+    function Notify.StopEntityPulse(Entity)
+        HoveredEntities[Entity] = nil
+    end
+end
+
+-- Another notification library helper...
+do
+    function Notify.InterpViewAngleTo(Target, Duration, OnComplete, CompleteThreshold)
+        Duration = Duration or 0.3
+        CompleteThreshold = CompleteThreshold or 1
+
+        local View = render.GetViewSetup()
+        local Start = View.angles
+        local StartTime = CurTime()
+
+        hook.Add("Think", "ACF_NotifyInterpViewAngleTo", function()
+            local Frac = math.Clamp((CurTime() - StartTime) / Duration, 0, 1)
+            local Ang = LerpAngle(math.ease.InOutCubic(Frac), Start, Target)
+            LocalPlayer():SetEyeAngles(Ang)
+
+            if Frac >= CompleteThreshold and OnComplete then
+                OnComplete()
+                OnComplete = nil
+            end
+            if Frac >= 1 then
+                hook.Remove("Think", "ACF_NotifyInterpViewAngleTo")
+            end
+        end)
+    end
+    hook.Remove("Think", "ACF_NotifyInterpViewAngleTo")
+end
+
+-- Toast notifications (mostly for notification errors)
+do
+    local ACF_NotificationToast = {}
+    local ACF_NotificationToasts = {}
+
+    function ACF_NotificationToast:SetText(Text)
+        self.Text = Text
+        surface.SetFont("DermaDefault")
+        local W, H = surface.GetTextSize(Text)
+        self.DesiredW, self.DesiredH = W + 8 + H + 16, H + 8
+    end
+
+    function ACF_NotificationToast:SetType(Type)
+        self.Icon = Material("icon16/" .. Type .. ".png")
+    end
+
+    function ACF_NotificationToast:SetDeathTime(Time)
+        self.DeathTime = Time
+        self.Birth = RealTime()
+        self.TTL = Time - self.Birth
+    end
+
+    function ACF_NotificationToast:GetTimeLeftToLive()
+        return self.TTL - (RealTime() - self.Birth)
+    end
+
+    function ACF_NotificationToast:GetLifeTime()
+        return RealTime() - self.Birth
+    end
+
+    function ACF_NotificationToast:Paint(W, H)
+        local M = surface.GetAlphaMultiplier()
+        surface.SetAlphaMultiplier(
+            math.ease.OutQuad(math.Clamp(self:GetLifeTime() * 1.7, 0, 1))
+            * math.ease.InQuart(math.Clamp(self:GetTimeLeftToLive() * 1.7, 0, 1))
+        )
+
+        DPanel.Paint(self, W, H)
+        draw.SimpleText(self.Text, "DermaDefault", (W / 2) + (H / 2), H / 2, self:GetSkin().Colours.Label.Dark, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
+        surface.SetMaterial(self.Icon)
+        surface.DrawTexturedRect(2 + 4, 2, H - 4, H - 4)
+        surface.SetAlphaMultiplier(M)
+    end
+
+    function ACF_NotificationToast:Think()
+        if not self.DeathTime then
+            ErrorNoHaltWithStack("No death time???")
+            self:Remove()
+            return
+        end
+
+        if RealTime() > self.DeathTime then
+            self:Remove()
+            return
+        end
+
+        local LifeMult = math.Clamp(self:GetLifeTime() * 2, 0, 1)
+        self:SetSize(self.DesiredW * math.ease.OutBack(LifeMult), self.DesiredH)
+    end
+
+    hook.Add("Think", "ACF_NotificationToasts_Think", function()
+        for Panel in pairs(ACF_NotificationToasts) do
+            local Parent = IsValid(Panel) and Panel.Parent
+            if IsValid(Panel) and Parent ~= nil then
+                local PnlW, PnlH = Panel:GetWide(), Panel:GetTall()
+                local X, Y = Panel.DesiredX, Panel.DesiredY
+                if Parent ~= false and IsValid(Parent) then
+                    if Panel.RelativeCoords then
+                        X, Y = (X * Parent:GetWide()), (Y * Parent:GetTall())
+                    end
+                    X, Y = Parent:LocalToScreen(X, Y)
+                end
+
+                Y = Y + math.ease.InQuad(math.Clamp(Panel:GetTimeLeftToLive() * 2, 0, 1))
+                Panel:SetPos(X - (PnlW / 2), Y - (PnlH / 2))
+            else
+                ACF_NotificationToasts[Panel] = nil
+            end
+        end
+    end)
+    vgui.Register("ACF_NotificationToast", ACF_NotificationToast, "DPanel")
+
+    function Notify.ToastAtXY(X, Y, Text, Type, Time)
+        local Panel = vgui.Create("ACF_NotificationToast", GetOverlayPanel and GetOverlayPanel() or nil)
+        Panel.DesiredX = X
+        Panel.Parent   = false
+        Panel.DesiredY = Y
+        Panel:SetText(Text)
+        Panel:SetType(Type)
+        Panel:SetDeathTime(RealTime() + (Time or 5))
+        ACF_NotificationToasts[Panel] = true
+    end
+
+    function Notify.ToastAtParent(Parent, X, Y, Relative, Text, Type, Time)
+        local Panel = vgui.Create("ACF_NotificationToast", GetOverlayPanel and GetOverlayPanel() or nil)
+        Panel.DesiredX = X
+        Panel.Parent   = Parent
+        Panel.RelativeCoords = Relative or false
+        Panel.DesiredY = Y
+        Panel:SetText(Text)
+        Panel:SetType(Type)
+        Panel:SetDeathTime(RealTime() + (Time or 5))
+        ACF_NotificationToasts[Panel] = true
+    end
+end
+
+do
+    local PANEL = {}
+
+    local function PulsingPaintFunction(self, w, h)
+        DButton.Paint(self, w, h)
+        local Skin = self:GetSkin()
+        surface.SetAlphaMultiplier(math.Remap(math.sin(CurTime() * 7), -1, 1, 0.6, 1))
+        Skin.tex.Selection(0, 0, w + 6, h)
+    end
+
+    local function CallActionButtonFunction(self)
+        Notify.CallAction(self.ActionContext)
+    end
+
+    local function DoErrorButtonFunction(self, Text)
+        Notify.ToastAtParent(self, 0.5, 1.5, true, Text, "error")
+    end
+
+    local function SetupButtonFunctions(RealButton, ButtonData)
+        RealButton.DoClick = CallActionButtonFunction
+        RealButton.DoError = DoErrorButtonFunction
+
+        if ButtonData.Pulsing then
+            RealButton.Paint = PulsingPaintFunction
+        end
+    end
+
+    function PANEL:Init()
+        self.Progress = true
+        self:DockPadding( 3, 3, 3, 3 )
+
+        self.Label = vgui.Create("DLabel", self)
+        self.Label:SetFont("GModNotify")
+        self.Label:SetTextColor(color_white)
+        self.Label:SetExpensiveShadow(1, Color( 0, 0, 0, 200 ))
+        self.Label:SetContentAlignment(4)
+
+        self.Desc = vgui.Create("DLabel", self)
+        self.Desc:SetFont("ACF_GModNotify_Description")
+        self.Desc:SetTextColor(color_white)
+        self.Desc:SetExpensiveShadow(1, Color( 0, 0, 0, 200 ))
+        self.Desc:SetContentAlignment(7)
+
+        self:SetBackgroundColor( Color( 20, 20, 20, 255 * 0.6 ))
+        self:SizeToContents()
+        self.Buttons = {}
+    end
+
+    local function ApplySizing(wide, tall, Label)
+        surface.SetFont(Label:GetFont())
+        local tw, th = surface.GetTextSize(Label:GetText())
+        wide = math.max(wide, tw + 32)
+        tall = tall + th
+        return wide, tall
+    end
+
+    function PANEL:PerformLayout(W, H)
+        local LW, LH = ApplySizing(0, 0, self.Label)
+        local DW, DH = ApplySizing(0, 0, self.Desc)
+
+        if IsValid(self.Image) then
+            self.Image:SetPos(6, 6)
+            self.Image:SetSize(20, 20)
+
+            self.Label:SetPos(24 + 8, 4)
+            self.Label:SetSize(LW, LH)
+            self.Desc:SetPos(8, 8 + LH)
+            self.Desc:SetSize(DW, DH)
+        else
+            self.Label:SetPos(4, 4)
+            self.Label:SetSize(LW, LH)
+            self.Desc:SetPos(8, 4 + LH)
+            self.Desc:SetSize(DW, DH)
+        end
+
+        local ButtonGutterPadding = 16
+        local ButtonGutterX = ButtonGutterPadding
+        local ButtonGutterY = H - 48
+        local ButtonGutterWidth = W - (ButtonGutterPadding * 2)
+
+        local SpaceInbetweenButtons = 4
+
+        local PerButtonWidth = ButtonGutterWidth / #self.Buttons
+        for I, Button in ipairs(self.Buttons) do
+            Button:SetPos(ButtonGutterX + ((I - 1) * PerButtonWidth) + SpaceInbetweenButtons, ButtonGutterY)
+            Button:SetSize(PerButtonWidth - (SpaceInbetweenButtons * 2), 24)
+        end
+    end
+
+    function PANEL:SizeToContents()
+        local wide, tall = 0, 0
+
+        wide, tall = ApplySizing(wide, tall, self.Label)
+        wide, tall = ApplySizing(wide, tall, self.Desc)
+
+        if IsValid(self.Image) then
+            wide = wide + 24
+        end
+
+        local HasButtons = self.Buttons ~= nil and #self.Buttons ~= 0
+
+        tall = tall + 48
+        if HasButtons then
+            tall = tall + 16
+        end
+        self:SetSize(wide, tall)
+        self.DesiredWidth = wide
+        self.DesiredHeight = tall
+        self:InvalidateLayout()
+    end
+
+    function PANEL:SetData(Data)
+        for _, Btn in ipairs(self.Buttons) do Btn:Remove() end
+        self.Buttons = {}
+
+        self.Label:SetText(string.format(unpack(Data.Title)))
+        self.Desc:SetText(string.format(unpack(Data.Description)))
+
+        if Data.Icon then
+            local T = type(Data.Icon)
+            if T == "string" and #Data.Icon > 0 then
+                self.Image = vgui.Create( "DImageButton", self )
+                self.Image:SetMaterial(Material(Data.Icon, "smooth"))
+                self.Image:SetSize( 32, 32)
+                self.Image.DoClick = function()
+                    self.StartTime = 0
+                end
+                self.Image:MoveToBack()
+            end
+        end
+
+        for _, ButtonData in ipairs(Data.Buttons) do
+            local RealButton = vgui.Create("DButton", self)
+            self.Buttons[#self.Buttons + 1] = RealButton
+
+            RealButton:SetBright(false)
+            RealButton.ActionContext = Notify.CreateActionContext(self, ButtonData.Params, RealButton, ButtonData.Action) -- This object gets reused for a few button callbacks.
+            -- So this gets stored in the button itself so it doesnt have to be remade all the time
+
+            RealButton:SetText(string.format(unpack(ButtonData.Text)))
+            SetupButtonFunctions(RealButton, ButtonData)
+        end
+
+        self:SizeToContents()
+    end
+
+    function PANEL:Think()
+        -- If the player is hovering over this, then keep it alive
+        local RecursiveHoverCheck = false
+        local RecursiveHoverCheckElement = vgui.GetHoveredPanel()
+        while IsValid(RecursiveHoverCheckElement) do
+            if RecursiveHoverCheckElement == self then
+                RecursiveHoverCheck = true
+                break
+            end
+
+            RecursiveHoverCheckElement = RecursiveHoverCheckElement:GetParent()
+        end
+
+        if RecursiveHoverCheck then
+            self.StartTime = self.StartTime + RealFrameTime()
+        end
+    end
+
+    function PANEL:Paint( w, h )
+        self.ProgressFrac = (SysTime() - self.StartTime) / self.Length
+        local shouldDraw = not (LocalPlayer and IsValid(LocalPlayer()) and IsValid(LocalPlayer():GetActiveWeapon()) and LocalPlayer():GetActiveWeapon():GetClass() == "gmod_camera")
+
+        if IsValid(self.Label) then self.Label:SetVisible(shouldDraw) end
+        if IsValid(self.Image) then self.Image:SetVisible(shouldDraw) end
+
+        if not shouldDraw then return end
+
+        local Skin = self:GetSkin()
+        Skin.tex.Panels.Normal(0, 0, w, h, self.m_bgColor )
+
+        if not self.Progress then return end
+
+        local BoxX, BoxY = 10, self:GetTall() - 13
+        local BoxW, BoxH = self:GetWide() - 20, 5
+
+        local BoxInnerW = BoxW - 2
+
+        surface.SetDrawColor(0, 100, 0, 150)
+        surface.DrawRect(BoxX, BoxY, BoxW, BoxH)
+
+        surface.SetDrawColor(0, 50, 0, 255)
+        surface.DrawRect(BoxX + 1, BoxY + 1, BoxW - 2, BoxH - 2)
+
+        local w = math.ceil(BoxInnerW * 0.25)
+        local x = math.fmod(math.floor(SysTime() * 200), BoxInnerW + w) - w
+
+        if self.ProgressFrac then
+            x = 0
+            w = math.ceil(BoxInnerW * self.ProgressFrac)
+        end
+
+        if x + w > BoxInnerW then w = math.ceil(BoxInnerW - x) end
+        if x < 0 then
+            w = w + x
+            x = 0
+        end
+        surface.SetDrawColor(232, 243, 255)
+        surface.DrawRect(BoxX + 1 + x, BoxY + 1, w, BoxH - 2)
+    end
+
+    function PANEL:KillSelf()
+        if self.Length < 0 then return false end
+
+        if self.StartTime + self.Length < SysTime() then
+            self:Remove()
+            return true
+        end
+
+        return false
+    end
+
+    vgui.Register("ACF_NoticePanel", PANEL, "DPanel")
+end
+
+do -- Backwards compatibility with the old notification system.
+    local Messages = ACF.Utilities.Messages
+    local ReceiveShame = GetConVar("acf_legalshame")
+    local LastNotificationSoundTime = 0
+    net.Receive("ACF_LegacyNotify", function()
+        local IsOK = net.ReadBool()
+        local Msg  = net.ReadString()
+        local Type = IsOK and NOTIFY_GENERIC or NOTIFY_ERROR
+
+        local Now = SysTime()
+        local DeltaTime = Now - LastNotificationSoundTime
+
+        if not IsOK and DeltaTime > 0.2 then -- Rate limit sounds. Helps with lots of sudden errors not killing your ears
+            surface.PlaySound("buttons/button10.wav")
+            LastNotificationSoundTime = Now
+        end
+
+        Msg = "[ACF] " .. Msg
+        notification.AddLegacy(Msg, Type, 7)
+    end)
+
+    net.Receive("ACF_NameAndShame", function()
+        if not ReceiveShame:GetBool() then return end
+        Messages.PrintLog("Error", net.ReadString())
+    end)
+end

--- a/lua/acf/core/utilities/notify/notification_cl.lua
+++ b/lua/acf/core/utilities/notify/notification_cl.lua
@@ -329,7 +329,7 @@ do
             self.Image:SetPos(6, 6)
             self.Image:SetSize(20, 20)
 
-            self.Label:SetPos(24 + 8, 4)
+            self.Label:SetPos(24 + 8, 6)
             self.Label:SetSize(LW, LH)
             self.Desc:SetPos(8, 8 + LH)
             self.Desc:SetSize(DW, DH)

--- a/lua/acf/core/utilities/notify/notification_cl.lua
+++ b/lua/acf/core/utilities/notify/notification_cl.lua
@@ -85,7 +85,7 @@ do
     local TempEntityBufferSustained = {}
     local HaloColor = Color(210, 222, 255)
     hook.Add("PreDrawHalos", "ACF_DrawNotificationHolos", function()
-        if #Entities == 0 and #HoveredEntities == 0 then return end
+        if #Entities == 0 and not next(HoveredEntities) then return end
 
         local DeltaTime = RealFrameTime()
         local Time      = SysTime()
@@ -377,6 +377,9 @@ do
     end
 
     function PANEL:SetData(Data)
+        self.DataReference = Data
+        self.TargetEntity = Entity(Data.TargetEntity)
+
         for _, Btn in ipairs(self.Buttons) do Btn:Remove() end
         self.Buttons = {}
 
@@ -424,9 +427,14 @@ do
             RecursiveHoverCheckElement = RecursiveHoverCheckElement:GetParent()
         end
 
+        local TargetEntity = self.TargetEntity
         if RecursiveHoverCheck then
             self.StartTime = self.StartTime + RealFrameTime()
+            if IsValid(TargetEntity) then Notify.StartEntityPulse(TargetEntity) end
+        else
+            if IsValid(TargetEntity) then Notify.StopEntityPulse(TargetEntity) end
         end
+        self.RecursivelyHovered = RecursiveHoverCheck
     end
 
     function PANEL:Paint( w, h )

--- a/lua/acf/core/utilities/notify/notification_cl.lua
+++ b/lua/acf/core/utilities/notify/notification_cl.lua
@@ -366,9 +366,9 @@ do
 
         local HasButtons = self.Buttons ~= nil and #self.Buttons ~= 0
 
-        tall = tall + 48
+        tall = tall + 32
         if HasButtons then
-            tall = tall + 16
+            tall = tall + 32
         end
         self:SetSize(wide, tall)
         self.DesiredWidth = wide

--- a/lua/acf/core/utilities/notify/notification_cl.lua
+++ b/lua/acf/core/utilities/notify/notification_cl.lua
@@ -515,23 +515,6 @@ end
 do -- Backwards compatibility with the old notification system.
     local Messages = ACF.Utilities.Messages
     local ReceiveShame = GetConVar("acf_legalshame")
-    local LastNotificationSoundTime = 0
-    net.Receive("ACF_LegacyNotify", function()
-        local IsOK = net.ReadBool()
-        local Msg  = net.ReadString()
-        local Type = IsOK and NOTIFY_GENERIC or NOTIFY_ERROR
-
-        local Now = SysTime()
-        local DeltaTime = Now - LastNotificationSoundTime
-
-        if not IsOK and DeltaTime > 0.2 then -- Rate limit sounds. Helps with lots of sudden errors not killing your ears
-            surface.PlaySound("buttons/button10.wav")
-            LastNotificationSoundTime = Now
-        end
-
-        Msg = "[ACF] " .. Msg
-        notification.AddLegacy(Msg, Type, 7)
-    end)
 
     net.Receive("ACF_NameAndShame", function()
         if not ReceiveShame:GetBool() then return end

--- a/lua/acf/core/utilities/notify/notification_cl.lua
+++ b/lua/acf/core/utilities/notify/notification_cl.lua
@@ -333,6 +333,7 @@ do
     end
 
     local function ApplySizing(wide, tall, Label)
+        if not Label:IsVisible() then return wide, tall end
         surface.SetFont(Label:GetFont())
         local tw, th = surface.GetTextSize(Label:GetText())
         wide = math.max(wide, tw + 32)
@@ -403,7 +404,12 @@ do
         self.Buttons = {}
 
         self.Label:SetText(string.format(unpack(Data.Title)))
-        self.Desc:SetText(string.format(unpack(Data.Description)))
+        local DescriptionText = string.format(unpack(Data.Description))
+        if DescriptionText and #DescriptionText > 0 then
+            self.Desc:SetText(DescriptionText)
+        else
+            self.Desc:SetVisible(false)
+        end
 
         if Data.Icon then
             local T = type(Data.Icon)

--- a/lua/acf/core/utilities/notify/notification_cl.lua
+++ b/lua/acf/core/utilities/notify/notification_cl.lua
@@ -6,6 +6,18 @@ local MAX_BUTTON_BITS = 4
 -- This sucks but there's no better way to do it right now.
 local _, Notices = debug.getupvalue(notification.Kill, 1)
 
+local LastNotificationSoundTimes = {}
+
+local function SetLastNotificationSoundTime(Sound)
+    LastNotificationSoundTimes[Sound] = RealTime()
+end
+
+local function GetTimeSinceLastNotificationSoundPlayed(Sound)
+    local LastTime = LastNotificationSoundTimes[Sound]
+    if not LastTime then return 10000000 end
+    return RealTime() - LastTime
+end
+
 function Notify.Display(Data)
     local Parent = nil
     if GetOverlayPanel then Parent = GetOverlayPanel() end
@@ -21,6 +33,11 @@ function Notify.Display(Data)
     Panel:SetAlpha(255)
     Panel:SetPos(Panel.fx, Panel.fy)
 
+    if Data.Sound ~= nil and #Data.Sound > 0 and GetTimeSinceLastNotificationSoundPlayed(Data.Sound) >= 0.2 then
+        surface.PlaySound(Data.Sound)
+        SetLastNotificationSoundTime(Data.Sound)
+    end
+
     table.insert(Notices, Panel)
 end
 
@@ -30,6 +47,7 @@ do -- Receiving new notifications
         local Description = Notify.Net_ReadFormattedText()
         local Duration = net.ReadFloat()
         local Icon = net.ReadString()
+        local Sound = net.ReadString()
         local TargetEntityIdx = net.ReadUInt(MAX_EDICT_BITS)
         local TargetPhysObjIdx = net.ReadInt(10)
         local ButtonCount = net.ReadUInt(MAX_BUTTON_BITS)
@@ -54,6 +72,7 @@ do -- Receiving new notifications
             Description = Description,
             Duration = Duration,
             Icon = Icon,
+            Sound = Sound,
             Buttons = Buttons,
             TargetEntity = TargetEntityIdx,
             TargetPhysObj = TargetPhysObjIdx,

--- a/lua/acf/core/utilities/notify/notification_sh.lua
+++ b/lua/acf/core/utilities/notify/notification_sh.lua
@@ -27,7 +27,7 @@ end
 
 function Notify.Start()
     CurrentNotification.Title           = {"Title"}
-    CurrentNotification.Text            = {"Text"}
+    CurrentNotification.Text            = {""}
     CurrentNotification.Duration        = 8
     CurrentNotification.Icon            = "icon16/lightbulb.png"
     CurrentNotification.Sound           = ""

--- a/lua/acf/core/utilities/notify/notification_sh.lua
+++ b/lua/acf/core/utilities/notify/notification_sh.lua
@@ -290,4 +290,44 @@ do
         Notify.AddButton("Wiki Article...")
             :WithAction("OpenWiki", WikiArticle)
     end
+
+    function Notify.NotifyDisabledEntity(Ent, Reason, Ponder, WikiArticle)
+        if not IsValid(Ent) then return end
+
+        Notify.Start()
+        Notify.WithTitle("An ACF entity has been disabled.")
+        Notify.WithSilkIcon("error")
+        Notify.WithTargetEntity(Ent)
+        Notify.WithDescription(Reason)
+
+        Notify.AddButton("Look at Entity")
+            :WithAction("LookAtEntity", Ent)
+            :WithPulse()
+
+        if Ponder then Notify.AddPonderButton(Ponder) end
+        if WikiArticle then Notify.AddWikiArticleButton(WikiArticle) end
+
+        Notify.AddPlayer(Ent:CPPIGetOwner())
+        Notify.Transmit()
+    end
+
+    function Notify.NotifyWarning(Warning, Description, Ent)
+        Notify.Start()
+        Notify.WithTitle(Warning)
+        Notify.WithSilkIcon("error")
+        if Description then Notify.WithDescription(Description) end
+
+        if IsValid(Ent) then
+            Notify.WithTargetEntity(Ent)
+            Notify.AddButton("Look at Entity")
+                :WithAction("LookAtEntity", Ent)
+                :WithPulse()
+        end
+
+        if Ponder then Notify.AddPonderButton(Ponder) end
+        if WikiArticle then Notify.AddWikiArticleButton(WikiArticle) end
+
+        Notify.AddPlayer(Ent:CPPIGetOwner())
+        Notify.Transmit()
+    end
 end

--- a/lua/acf/core/utilities/notify/notification_sh.lua
+++ b/lua/acf/core/utilities/notify/notification_sh.lua
@@ -278,3 +278,16 @@ do
         end
     end
 end
+
+-- Some useful helper functions
+do
+    function Notify.AddPonderButton(Ponder)
+        Notify.AddButton("Ponder About...")
+            :WithAction("OpenPonder", Ponder)
+    end
+
+    function Notify.AddWikiArticleButton(WikiArticle)
+        Notify.AddButton("Wiki Article...")
+            :WithAction("OpenWiki", WikiArticle)
+    end
+end

--- a/lua/acf/core/utilities/notify/notification_sh.lua
+++ b/lua/acf/core/utilities/notify/notification_sh.lua
@@ -30,6 +30,7 @@ function Notify.Start()
     CurrentNotification.Text            = {"Text"}
     CurrentNotification.Duration        = 8
     CurrentNotification.Icon            = "icon16/lightbulb.png"
+    CurrentNotification.Sound           = ""
     CurrentNotification.Buttons         = {}
     CurrentNotification.TargetEntity    = 0
     CurrentNotification.TargetPhysObj   = -1
@@ -39,11 +40,13 @@ function Notify.Start()
     end
 end
 
-function Notify.WithTitle(Title, ...) CurrentNotification.Title = {Title, ...} end
-function Notify.WithDescription(Text, ...) CurrentNotification.Text = {Text, ...} end
-function Notify.Duration(Duration) CurrentNotification.Duration = Duration end
-function Notify.WithIcon(Icon) CurrentNotification.Icon = Icon end
-function Notify.WithSilkIcon(Icon) Notify.WithIcon("icon16/" .. Icon .. ".png") end
+function Notify.WithTitle(Title, ...) CurrentNotification.Title = {Title or "", ...} end
+function Notify.WithDescription(Text, ...) CurrentNotification.Text = {Text or "", ...} end
+function Notify.Duration(Duration) CurrentNotification.Duration = Duration or 0 end
+function Notify.WithIcon(Icon) CurrentNotification.Icon = Icon or "" end
+function Notify.WithSound(Sound) CurrentNotification.Sound = Sound or "" end
+function Notify.WithErrorSound() CurrentNotification.Sound = "buttons/button10.wav" end
+function Notify.WithSilkIcon(Icon) if Icon then Notify.WithIcon("icon16/" .. Icon .. ".png") end end
 function Notify.WithTargetEntity(Entity) CurrentNotification.TargetEntity = IsValid(Entity) and Entity:EntIndex() or 0 end
 function Notify.WithTargetPhysObj(PhysObj)
     if not IsValid(PhysObj) then
@@ -130,6 +133,7 @@ function Notify.Transmit()
         Notify.Net_WriteFormattedText(CurrentNotification.Text)
         net.WriteFloat(CurrentNotification.Duration)
         net.WriteString(CurrentNotification.Icon)
+        net.WriteString(CurrentNotification.Sound)
         net.WriteUInt(CurrentNotification.TargetEntity, MAX_EDICT_BITS)
         net.WriteInt(CurrentNotification.TargetPhysObj, 10)
         net.WriteUInt(#CurrentNotification.Buttons, MAX_BUTTON_BITS)
@@ -290,15 +294,21 @@ do
         Notify.AddButton("Wiki Article...")
             :WithAction("OpenWiki", WikiArticle)
     end
+end
 
-    function Notify.NotifyDisabledEntity(Ent, Reason, Ponder, WikiArticle)
+do
+    --
+    -- Disabled warnings
+    --
+    function Notify.EntityDisabledToPlayer(Ent, Player, Reason, Ponder, WikiArticle)
         if not IsValid(Ent) then return end
 
         Notify.Start()
         Notify.WithTitle("An ACF entity has been disabled.")
-        Notify.WithSilkIcon("error")
+        Notify.WithSilkIcon("exclamation")
         Notify.WithTargetEntity(Ent)
         Notify.WithDescription(Reason)
+        Notify.WithErrorSound()
 
         Notify.AddButton("Look at Entity")
             :WithAction("LookAtEntity", Ent)
@@ -307,27 +317,104 @@ do
         if Ponder then Notify.AddPonderButton(Ponder) end
         if WikiArticle then Notify.AddWikiArticleButton(WikiArticle) end
 
-        Notify.AddPlayer(Ent:CPPIGetOwner())
+        Notify.AddPlayer(Player)
         Notify.Transmit()
+        return true
     end
 
-    function Notify.NotifyWarning(Warning, Description, Ent)
-        Notify.Start()
-        Notify.WithTitle(Warning)
-        Notify.WithSilkIcon("error")
-        if Description then Notify.WithDescription(Description) end
+    --
+    -- Warnings will play sounds
+    --
+    function Notify.WarningToPlayer(Player, Title, Description, Ponder, WikiArticle)
+        if not IsValid(Player) then return end
 
-        if IsValid(Ent) then
-            Notify.WithTargetEntity(Ent)
-            Notify.AddButton("Look at Entity")
-                :WithAction("LookAtEntity", Ent)
-                :WithPulse()
-        end
+        Notify.Start()
+        Notify.WithTitle(Title)
+        Notify.WithSilkIcon("error")
+        Notify.WithErrorSound()
+        if Description then Notify.WithDescription(Description) end
 
         if Ponder then Notify.AddPonderButton(Ponder) end
         if WikiArticle then Notify.AddWikiArticleButton(WikiArticle) end
 
-        Notify.AddPlayer(Ent:CPPIGetOwner())
+        Notify.AddPlayer(Player)
         Notify.Transmit()
+
+        return true
+    end
+
+    function Notify.EntityWarningToPlayer(Ent, Player, Title, Description, Ponder, WikiArticle)
+        if not IsValid(Ent) then return end
+        if not IsValid(Player) then return end
+
+        Notify.Start()
+        Notify.WithTitle(Title)
+        Notify.WithSilkIcon("error")
+        Notify.WithErrorSound()
+        if Description then Notify.WithDescription(Description) end
+
+        Notify.WithTargetEntity(Ent)
+        Notify.AddButton("Look at Entity")
+            :WithAction("LookAtEntity", Ent)
+            :WithPulse()
+
+        if Ponder then Notify.AddPonderButton(Ponder) end
+        if WikiArticle then Notify.AddWikiArticleButton(WikiArticle) end
+
+        Notify.AddPlayer(Player)
+        Notify.Transmit()
+
+        return true
+    end
+
+    function Notify.EntityWarning(Ent, Title, Description, Ponder, WikiArticle)
+        if not IsValid(Ent) then return end
+        return Notify.EntityWarningToPlayer(Ent, Ent:CPPIGetOwner(), Title, Description, Ponder, WikiArticle)
+    end
+
+    --
+    -- Notices won't play sounds.
+    --
+    function Notify.NoticeToPlayer(Player, Title, Description, Ponder, WikiArticle)
+        if not IsValid(Player) then return end
+
+        Notify.Start()
+        Notify.WithTitle(Title)
+        if Description then Notify.WithDescription(Description) end
+
+        if Ponder then Notify.AddPonderButton(Ponder) end
+        if WikiArticle then Notify.AddWikiArticleButton(WikiArticle) end
+
+        Notify.AddPlayer(Player)
+        Notify.Transmit()
+
+        return true
+    end
+
+    function Notify.EntityNoticeToPlayer(Ent, Player, Title, Description, Ponder, WikiArticle)
+        if not IsValid(Ent) then return end
+        if not IsValid(Player) then return end
+
+        Notify.Start()
+        Notify.WithTitle(Title)
+        if Description then Notify.WithDescription(Description) end
+
+        Notify.WithTargetEntity(Ent)
+        Notify.AddButton("Look at Entity")
+            :WithAction("LookAtEntity", Ent)
+            :WithPulse()
+
+        if Ponder then Notify.AddPonderButton(Ponder) end
+        if WikiArticle then Notify.AddWikiArticleButton(WikiArticle) end
+
+        Notify.AddPlayer(Player)
+        Notify.Transmit()
+
+        return true
+    end
+
+    function Notify.EntityNotice(Ent, Title, Description, Ponder, WikiArticle)
+        if not IsValid(Ent) then return end
+        return Notify.EntityNoticeToPlayer(Ent, Ent:CPPIGetOwner(), Title, Description, Ponder, WikiArticle)
     end
 end

--- a/lua/acf/core/utilities/notify/notification_sh.lua
+++ b/lua/acf/core/utilities/notify/notification_sh.lua
@@ -199,4 +199,12 @@ do
             Notify.InterpViewAngleTo(Lookat, nil, function() Notify.SingleEntityImpulse(Entity) end, 0.8)
         end
     end
+
+    do
+        local OpenPonder = Notify.RegisterAction("OpenPonder")
+        function OpenPonder.DoClickCL(Context, UUID)
+            if not Ponder then return Context:DoButtonError("Ponder is not installed.") end -- This shouldn't even show up in the future
+            Ponder.Open(UUID)
+        end
+    end
 end

--- a/lua/acf/core/utilities/notify/notification_sh.lua
+++ b/lua/acf/core/utilities/notify/notification_sh.lua
@@ -202,9 +202,51 @@ do
 
     do
         local OpenPonder = Notify.RegisterAction("OpenPonder")
-        function OpenPonder.DoClickCL(Context, UUID)
+        function OpenPonder.DoClickCL(_, UUID)
             if not Ponder then return Context:DoButtonError("Ponder is not installed.") end -- This shouldn't even show up in the future
             Ponder.Open(UUID)
+        end
+    end
+
+    do
+        local OpenWiki = Notify.RegisterAction("OpenWiki")
+
+        function OpenWiki.DoClickCL(_, URL)
+            URL = "https://lengthenedgradient.github.io/Wiki/docs/" .. URL
+            local Panel = vgui.Create("DPanel")
+            local startTime = SysTime()
+
+            Panel:SetSize(ScrW() * 0.85, ScrH() * 0.85)
+            Panel:Center()
+            Panel:MakePopup()
+
+            local BackColor = color_white:Copy()
+            BackColor.a = 0
+            local Back = Panel:Add("DButton")
+            Back:Dock(TOP)
+            Back:SetPaintBackground(false)
+            Back:SetColor(BackColor)
+            Back:SetText("Exit")
+            Back:SetFont("ACF_Title")
+            function Back:DoClick()
+                Panel:Remove()
+            end
+
+            local HTML = Panel:Add("DHTML")
+            HTML:Dock(FILL)
+            HTML:OpenURL(URL)
+            HTML:DockMargin(16, 16, 16, 16)
+
+            local DHTML_Paint = HTML.Paint
+            function HTML:Paint(W, H)
+                DHTML_Paint(self, W, H)
+            end
+
+            function Panel:Paint()
+                Derma_DrawBackgroundBlur(self, startTime)
+                BackColor.a = math.ease.InCubic(math.Clamp(SysTime() - startTime - 0.6, 0, 1)) * 255
+                Back:SetColor(BackColor)
+            end
         end
     end
 end

--- a/lua/acf/core/utilities/notify/notification_sh.lua
+++ b/lua/acf/core/utilities/notify/notification_sh.lua
@@ -242,10 +242,38 @@ do
                 DHTML_Paint(self, W, H)
             end
 
-            function Panel:Paint()
+            function Panel:Paint(W, H)
                 Derma_DrawBackgroundBlur(self, startTime)
                 BackColor.a = math.ease.InCubic(math.Clamp(SysTime() - startTime - 0.6, 0, 1)) * 255
                 Back:SetColor(BackColor)
+
+                local Size = ScrH() * 0.05
+                local CenterX, CenterY = W / 2, H / 2
+                local Radius = Size / 2
+                local Spokes = 12
+                local Time = SysTime()
+                for I = 0, Spokes - 1 do
+                    local Angle = math.rad((I / Spokes) * 360 - 90)
+                    local Frac = 1 - (((I / Spokes) + Time * 1.5) % 1)
+                    local Alpha = Frac * 100
+                    local Thick = Size * 0.02
+                    local InnerRadius = Radius * 0.4
+                    local OuterRadius = Radius * 0.85
+                    local X1 = CenterX + math.cos(Angle) * InnerRadius
+                    local Y1 = CenterY + math.sin(Angle) * InnerRadius
+                    local X2 = CenterX + math.cos(Angle) * OuterRadius
+                    local Y2 = CenterY + math.sin(Angle) * OuterRadius
+                    surface.SetDrawColor(255, 255, 255, Alpha)
+                    surface.DrawLine(X1, Y1, X2, Y2)
+                    for T = -Thick / 2, Thick / 2 do
+                        local Offset = math.abs(Angle) < math.rad(45) or math.abs(Angle - math.pi) < math.rad(45)
+                        if Offset then
+                            surface.DrawLine(X1, Y1 + T, X2, Y2 + T)
+                        else
+                            surface.DrawLine(X1 + T, Y1, X2 + T, Y2)
+                        end
+                    end
+                end
             end
         end
     end

--- a/lua/acf/core/utilities/notify/notification_sh.lua
+++ b/lua/acf/core/utilities/notify/notification_sh.lua
@@ -1,0 +1,192 @@
+local Notify = ACF.Utilities.Notify
+
+local CurrentNotification = {}
+
+-- Text is networked as a sequential table. The first value is expected to always be text. The remaining values are networked over
+-- and inserted into the format string on client.
+
+local MAX_FORMATTED_TEXT_PARAM_BITS = 8
+local MAX_BUTTON_BITS = 4
+
+function Notify.Net_ReadFormattedText()
+    local FormattedTextObject = {}
+    local Count = net.ReadUInt(MAX_FORMATTED_TEXT_PARAM_BITS)
+    for I = 1, Count do
+        FormattedTextObject[I] = net.ReadType()
+    end
+
+    return FormattedTextObject
+end
+
+function Notify.Net_WriteFormattedText(FormattedTextObject)
+    net.WriteUInt(#FormattedTextObject, MAX_FORMATTED_TEXT_PARAM_BITS)
+    for I = 1, #FormattedTextObject do
+        net.WriteType(FormattedTextObject[I])
+    end
+end
+
+function Notify.Start()
+    CurrentNotification.Title           = {"Title"}
+    CurrentNotification.Text            = {"Text"}
+    CurrentNotification.Duration        = 8
+    CurrentNotification.Icon            = "icon16/lightbulb.png"
+    CurrentNotification.Buttons         = {}
+    CurrentNotification.TargetEntity    = 0
+    CurrentNotification.TargetPhysObj   = -1
+    if SERVER then
+        CurrentNotification.Filter = CurrentNotification.Filter or RecipientFilter()
+        CurrentNotification.Filter:RemoveAllPlayers()
+    end
+end
+
+function Notify.WithTitle(Title, ...) CurrentNotification.Title = {Title, ...} end
+function Notify.WithDescription(Text, ...) CurrentNotification.Text = {Text, ...} end
+function Notify.Duration(Duration) CurrentNotification.Duration = Duration end
+function Notify.WithIcon(Icon) CurrentNotification.Icon = Icon end
+function Notify.WithSilkIcon(Icon) Notify.WithIcon("icon16/" .. Icon .. ".png") end
+function Notify.WithTargetEntity(Entity) CurrentNotification.TargetEntity = IsValid(Entity) and Entity:EntIndex() or 0 end
+function Notify.WithTargetPhysObj(PhysObj)
+    if not IsValid(PhysObj) then
+        CurrentNotification.TargetEntity = 0
+        CurrentNotification.TargetPhysObj = -1
+        return
+    end
+
+    Notify.WithTargetEntity(PhysObj:GetEntity())
+    CurrentNotification.TargetPhysObj = PhysObj:GetIndex()
+end
+
+local function ActionSetFunction(self, Action, ...)
+    self.Action = Action
+    self.Params = {...}
+    return self
+end
+
+local function ActionPulsing(self)
+    self.Pulsing = true
+    return self
+end
+
+function Notify.AddButton(Text, ...)
+    local Button = {
+        Text = {Text, ...},
+        Action = "",
+        Params = {},
+        Pulsing = false
+    }
+    CurrentNotification.Buttons[#CurrentNotification.Buttons + 1] = Button
+    Button.WithAction = ActionSetFunction
+    Button.WithPulse = ActionPulsing
+    return Button
+end
+
+-- Recipient filter features.
+if SERVER then
+    function Notify.AddAllPlayers(...) CurrentNotification.Filter:AddAllPlayers(...) end
+    function Notify.AddPAS(...) CurrentNotification.Filter:AddPAS(...) end
+    function Notify.AddPlayer(...) CurrentNotification.Filter:AddPlayer(...) end
+    function Notify.AddPlayers(...) CurrentNotification.Filter:AddPlayers(...) end
+    function Notify.AddPVS(...) CurrentNotification.Filter:AddPVS(...) end
+    function Notify.RemoveAllPlayers(...) CurrentNotification.Filter:RemoveAllPlayers(...) end
+    function Notify.RemoveMismatchedPlayers(...) CurrentNotification.Filter:RemoveMismatchedPlayers(...) end
+    function Notify.RemovePAS(...) CurrentNotification.Filter:RemovePAS(...) end
+    function Notify.RemovePlayer(...) CurrentNotification.Filter:RemovePlayer(...) end
+    function Notify.RemovePlayers(...) CurrentNotification.Filter:RemovePlayers(...) end
+    function Notify.RemovePVS(...) CurrentNotification.Filter:RemovePVS(...) end
+    function Notify.RemoveRecipientsByTeam(...) CurrentNotification.Filter:RemoveRecipientsByTeam(...) end
+    function Notify.RemoveRecipientsNotOnTeam(...) CurrentNotification.Filter:RemoveRecipientsNotOnTeam(...) end
+else -- Nulled out functions for clientside.
+    function Notify.AddAllPlayers() end
+    function Notify.AddPAS() end
+    function Notify.AddPlayer() end
+    function Notify.AddPlayers() end
+    function Notify.AddPVS() end
+    function Notify.RemoveAllPlayers() end
+    function Notify.RemoveMismatchedPlayers() end
+    function Notify.RemovePAS() end
+    function Notify.RemovePlayer() end
+    function Notify.RemovePlayers() end
+    function Notify.RemovePVS() end
+    function Notify.RemoveRecipientsByTeam() end
+    function Notify.RemoveRecipientsNotOnTeam() end
+end
+
+function Notify.Transmit()
+    if CLIENT then
+        Notify.Display(CurrentNotification)
+    else
+        net.Start("ACF_Notify")
+        Notify.Net_WriteFormattedText(CurrentNotification.Title)
+        Notify.Net_WriteFormattedText(CurrentNotification.Text)
+        net.WriteFloat(CurrentNotification.Duration)
+        net.WriteString(CurrentNotification.Icon)
+        net.WriteUInt(CurrentNotification.TargetEntity, MAX_EDICT_BITS)
+        net.WriteInt(CurrentNotification.TargetPhysObj, 10)
+        net.WriteUInt(#CurrentNotification.Buttons, MAX_BUTTON_BITS)
+        for I = 1, #CurrentNotification.Buttons do
+            local Button = CurrentNotification.Buttons[I]
+            Notify.Net_WriteFormattedText(Button.Text)
+            net.WriteBool(Button.Pulsing)
+            net.WriteString(Button.Action)
+            net.WriteUInt(#Button.Params, 6)
+            for I2 = 1, #Button.Params do
+                net.WriteType(Button.Params[I2])
+            end
+        end
+
+        net.Send(CurrentNotification.Filter)
+    end
+end
+
+-- Notification actions API.
+do
+    Notify.Actions = {}
+
+    -- Handlers are given an ActionContext (allows interacting with the prompt a little if need be), and  
+    function Notify.RegisterAction(ActionName)
+        local Obj = Notify.Actions[ActionName] or {}
+        Notify.Actions[ActionName] = Obj
+        return Obj
+    end
+
+    if CLIENT then
+        local ActionContextFns = {}
+        local ActionContextMT = {__index = ActionContextFns}
+
+        function ActionContextFns:GetActionName() return self.ActionName end
+        function ActionContextFns:GetActionParams() return self.ActionParams end
+        function ActionContextFns:GetNotifyPanel() return self.Panel end
+        function ActionContextFns:GetActionButton() return self.ActionButton end
+
+        function ActionContextFns:GetNotifyData() return self.Panel.Data end
+        function ActionContextFns:GetTargetEntity() return Entity(self.Panel.Data.TargetEntity) end
+        function ActionContextFns:DoButtonError(Reason)
+            if not IsValid(self.ActionButton) then return end
+            self.ActionButton:DoError(Reason)
+        end
+
+        function Notify.CreateActionContext(NotifyPanel, ActionParams, ActionButton, ActionName)
+            return setmetatable({ActionName = ActionName, ActionParams = ActionParams, Panel = NotifyPanel, ActionButton = ActionButton}, ActionContextMT)
+        end
+
+        function Notify.CallAction(ActionContext)
+            if not ActionContext or not ActionContext.ActionName then return end
+            local Action = Notify.Actions[ActionContext:GetActionName()]
+            if not Action then ErrorNoHalt("Action '" .. ActionContext:GetActionName() .. "' was not registered with the ACF notification subsystem.") return end
+            Action.DoClickCL(ActionContext, unpack(ActionContext:GetActionParams()))
+        end
+    end
+end
+
+-- Here are some base action types.
+do
+    do
+        local LookAt = Notify.RegisterAction("LookAtEntity")
+        function LookAt.DoClickCL(Context, Entity)
+            if not IsValid(Entity) then return Context:DoButtonError("The entity is no longer valid.") end
+            local View = render.GetViewSetup()
+            local Lookat = (Entity:WorldSpaceCenter() - View.origin):Angle()
+            Notify.InterpViewAngleTo(Lookat, nil, function() Notify.SingleEntityImpulse(Entity) end, 0.8)
+        end
+    end
+end

--- a/lua/acf/core/utilities/notify/notification_sh.lua
+++ b/lua/acf/core/utilities/notify/notification_sh.lua
@@ -82,6 +82,15 @@ end
 
 -- Recipient filter features.
 if SERVER then
+    function Notify.AddTargetEntityOwner()
+        local Ent = Entity(CurrentNotification.TargetEntity)
+        if not IsValid(Ent) then return end
+
+        local Owner = Ent:CPPIGetOwner()
+        if not IsValid(Owner) then return end
+
+        CurrentNotification.Filter:AddPlayer(Owner)
+    end
     function Notify.AddAllPlayers(...) CurrentNotification.Filter:AddAllPlayers(...) end
     function Notify.AddPAS(...) CurrentNotification.Filter:AddPAS(...) end
     function Notify.AddPlayer(...) CurrentNotification.Filter:AddPlayer(...) end
@@ -96,6 +105,7 @@ if SERVER then
     function Notify.RemoveRecipientsByTeam(...) CurrentNotification.Filter:RemoveRecipientsByTeam(...) end
     function Notify.RemoveRecipientsNotOnTeam(...) CurrentNotification.Filter:RemoveRecipientsNotOnTeam(...) end
 else -- Nulled out functions for clientside.
+    function Notify.AddTargetEntityOwner() end
     function Notify.AddAllPlayers() end
     function Notify.AddPAS() end
     function Notify.AddPlayer() end

--- a/lua/acf/core/utilities/notify/notification_sv.lua
+++ b/lua/acf/core/utilities/notify/notification_sv.lua
@@ -25,29 +25,3 @@ do -- Backwards compatibility with the old notification system.
         net.Send(Player)
     end
 end
-
--- Example on how this could work from the serverside
---[[
-local Notify = ACF.Utilities.Notify
-local function DisableEntity(Ent)
-    Notify.Start()
-    Notify.WithTitle("An ACF entity has been disabled.")
-    Notify.WithSilkIcon("error")
-    Notify.WithTargetEntity(Ent)
-    Notify.WithDescription("The entity is invisible to projectiles.")
-
-    Notify.AddButton("Look at Entity", Ent)
-        :WithAction("LookAtEntity", Ent)
-        :WithPulse()
-
-    Notify.AddButton("Ponder About...", Ent)
-        :WithAction("OpenPonder", "acf.tankbasics.armor")
-
-    Notify.AddButton("Wiki Article", Ent)
-        :WithAction("OpenWiki", "getting_started/first_tank/baseplate_aio.html#all-in-one-aio-controllers")
-
-    Notify.AddPlayer(player.GetAll()[1])
-    Notify.Transmit()
-end
-DisableEntity(Entity(88))
-]]

--- a/lua/acf/core/utilities/notify/notification_sv.lua
+++ b/lua/acf/core/utilities/notify/notification_sv.lua
@@ -27,6 +27,7 @@ do -- Backwards compatibility with the old notification system.
 end
 
 -- Example on how this could work from the serverside
+--[[
 local Notify = ACF.Utilities.Notify
 local function DisableEntity(Ent)
     Notify.Start()
@@ -42,3 +43,4 @@ local function DisableEntity(Ent)
     Notify.Transmit()
 end
 DisableEntity(Entity(87))
+]]

--- a/lua/acf/core/utilities/notify/notification_sv.lua
+++ b/lua/acf/core/utilities/notify/notification_sv.lua
@@ -1,6 +1,6 @@
 util.AddNetworkString("ACF_Notify")
 
-do -- Backwards compatibility with the old notification system.
+do -- Backwards compatibility with the old notification system. We should get rid of this once Missiles uses the new stuff.
     util.AddNetworkString("ACF_LegacyNotify")
     util.AddNetworkString("ACF_NameAndShame")
 

--- a/lua/acf/core/utilities/notify/notification_sv.lua
+++ b/lua/acf/core/utilities/notify/notification_sv.lua
@@ -1,7 +1,6 @@
 util.AddNetworkString("ACF_Notify")
 
-do -- Backwards compatibility with the old notification system. We should get rid of this once Missiles uses the new stuff.
-    util.AddNetworkString("ACF_LegacyNotify")
+do -- Backwards compatibility with the old notification system.
     util.AddNetworkString("ACF_NameAndShame")
 
     function ACF.Shame(Entity, Message)
@@ -16,12 +15,5 @@ do -- Backwards compatibility with the old notification system. We should get ri
         net.Start("ACF_NameAndShame")
             net.WriteString(ShameMsg)
         net.Broadcast()
-    end
-
-    function ACF.SendNotify(Player, Success, Message)
-        net.Start("ACF_LegacyNotify")
-            net.WriteBool(Success or false)
-            net.WriteString(Message or "")
-        net.Send(Player)
     end
 end

--- a/lua/acf/core/utilities/notify/notification_sv.lua
+++ b/lua/acf/core/utilities/notify/notification_sv.lua
@@ -35,12 +35,19 @@ local function DisableEntity(Ent)
     Notify.WithSilkIcon("error")
     Notify.WithTargetEntity(Ent)
     Notify.WithDescription("The entity is invisible to projectiles.")
-    Notify.AddButton("Look at the problematic entity", Ent)
+
+    Notify.AddButton("Look at Entity", Ent)
         :WithAction("LookAtEntity", Ent)
         :WithPulse()
+
+    Notify.AddButton("Ponder About...", Ent)
+        :WithAction("OpenPonder", "acf.tankbasics.armor")
+
+    Notify.AddButton("Wiki Article", Ent)
+        :WithAction("OpenWiki", "getting_started/first_tank/baseplate_aio.html#all-in-one-aio-controllers")
 
     Notify.AddPlayer(player.GetAll()[1])
     Notify.Transmit()
 end
-DisableEntity(Entity(87))
+DisableEntity(Entity(88))
 ]]

--- a/lua/acf/core/utilities/notify/notification_sv.lua
+++ b/lua/acf/core/utilities/notify/notification_sv.lua
@@ -1,0 +1,44 @@
+util.AddNetworkString("ACF_Notify")
+
+do -- Backwards compatibility with the old notification system.
+    util.AddNetworkString("ACF_LegacyNotify")
+    util.AddNetworkString("ACF_NameAndShame")
+
+    function ACF.Shame(Entity, Message)
+        if not ACF.NameAndShame then return end
+        local Owner = Entity:CPPIGetOwner()
+
+        if not IsValid(Owner) then return end
+
+        local ShameMsg = Owner:GetName() .. " had " .. tostring(Entity) .. " disabled for " .. Message
+        Messages.PrintLog("Error", ShameMsg)
+
+        net.Start("ACF_NameAndShame")
+            net.WriteString(ShameMsg)
+        net.Broadcast()
+    end
+
+    function ACF.SendNotify(Player, Success, Message)
+        net.Start("ACF_LegacyNotify")
+            net.WriteBool(Success or false)
+            net.WriteString(Message or "")
+        net.Send(Player)
+    end
+end
+
+-- Example on how this could work from the serverside
+local Notify = ACF.Utilities.Notify
+local function DisableEntity(Ent)
+    Notify.Start()
+    Notify.WithTitle("An ACF entity has been disabled.")
+    Notify.WithSilkIcon("error")
+    Notify.WithTargetEntity(Ent)
+    Notify.WithDescription("The entity is invisible to projectiles.")
+    Notify.AddButton("Look at the problematic entity", Ent)
+        :WithAction("LookAtEntity", Ent)
+        :WithPulse()
+
+    Notify.AddPlayer(player.GetAll()[1])
+    Notify.Transmit()
+end
+DisableEntity(Entity(87))

--- a/lua/acf/core/utilities/util_cl.lua
+++ b/lua/acf/core/utilities/util_cl.lua
@@ -23,34 +23,6 @@ do -- Custom fonts
 	})
 end
 
-do -- Networked notifications
-	local notification = notification
-	local Messages = ACF.Utilities.Messages
-	local ReceiveShame = GetConVar("acf_legalshame")
-	local LastNotificationSoundTime = 0
-	net.Receive("ACF_Notify", function()
-		local IsOK = net.ReadBool()
-		local Msg  = net.ReadString()
-		local Type = IsOK and NOTIFY_GENERIC or NOTIFY_ERROR
-
-		local Now = SysTime()
-		local DeltaTime = Now - LastNotificationSoundTime
-
-		if not IsOK and DeltaTime > 0.2 then -- Rate limit sounds. Helps with lots of sudden errors not killing your ears
-			surface.PlaySound("buttons/button10.wav")
-			LastNotificationSoundTime = Now
-		end
-
-		Msg = "[ACF] " .. Msg
-		notification.AddLegacy(Msg, Type, 7)
-	end)
-
-	net.Receive("ACF_NameAndShame", function()
-		if not ReceiveShame:GetBool() then return end
-		Messages.PrintLog("Error", net.ReadString())
-	end)
-end
-
 do -- Panel helpers
 	local Sorted = {}
 

--- a/lua/acf/core/utilities/util_sv.lua
+++ b/lua/acf/core/utilities/util_sv.lua
@@ -8,34 +8,6 @@ resource.AddFile("resource/fonts/16segments-basic.ttf")
 resource.AddFile("resource/fonts/conduit.ttf")
 resource.AddFile("resource/fonts/prototype.ttf")
 
-do -- Networked notifications
-	local Messages = ACF.Utilities.Messages
-
-	util.AddNetworkString("ACF_Notify")
-	util.AddNetworkString("ACF_NameAndShame")
-
-	function ACF.Shame(Entity, Message)
-		if not ACF.NameAndShame then return end
-		local Owner = Entity:CPPIGetOwner()
-
-		if not IsValid(Owner) then return end
-
-		local ShameMsg = Owner:GetName() .. " had " .. tostring(Entity) .. " disabled for " .. Message
-		Messages.PrintLog("Error", ShameMsg)
-
-		net.Start("ACF_NameAndShame")
-			net.WriteString(ShameMsg)
-		net.Broadcast()
-	end
-
-	function ACF.SendNotify(Player, Success, Message)
-		net.Start("ACF_Notify")
-			net.WriteBool(Success or false)
-			net.WriteString(Message or "")
-		net.Send(Player)
-	end
-end
-
 do -- HTTP Request
 	local NoRequest = true
 	local http      = http

--- a/lua/acf/core/utilities/util_sv.lua
+++ b/lua/acf/core/utilities/util_sv.lua
@@ -1,4 +1,5 @@
 local ACF = ACF
+local Notify = ACF.Utilities.Notify
 
 -- 16 Segments font created by ThorType
 -- Huge thanks to LiddulBOFH to help me get it working
@@ -505,7 +506,7 @@ do -- Entity linking
 			function()
 				local Status, Message = ACF.PerformClassLinkCheck(Source, Target)
 				if not Status then
-					ACF.SendNotify(Source:CPPIGetOwner(), false, Message or "A link has been automatically removed.")
+					Notify.EntityWarning(Source, Source:CPPIGetOwner(), "A link has been automatically removed.", Message or "No additional info was provided")
 				end
 			end,
 			function() return IsValid(Source) and IsValid(Target) end,
@@ -996,7 +997,7 @@ do
 		if IsValid(Baseplate) then
 			local Type = Baseplate:ACF_GetUserVar("BaseplateType")
 			if Type ~= AllowedType then
-				ACF.SendNotify(Entity:CPPIGetOwner(), false, string.format("%s was removed due to being on an invalid baseplate (got %s, expected %s)", Entity, Type, AllowedType))
+				Notify.WarningToPlayer(Entity:CPPIGetOwner(), string.format("%s was removed due to being on an invalid baseplate type", Entity), string.Format("Got %s, expected %s", Type, AllowedType))
 				Entity:Remove()
 				return
 			end

--- a/lua/acf/core/validation_sv.lua
+++ b/lua/acf/core/validation_sv.lua
@@ -4,6 +4,7 @@
 local ACF          = ACF
 local Contraption  = ACF.Contraption
 local ModelData	   = ACF.ModelData
+local Notify       = ACF.Utilities.Notify
 local StringFind   = string.find
 local TimerSimple  = timer.Simple
 local Baddies	   = ACF.GlobalFilter
@@ -97,10 +98,10 @@ function ACF.DisableEntity(Entity, Reason, Message, Timeout)
 				timer.Simple(1.1, function() -- Remover tool sets nodraw and removes 1 second later, causing annoying alerts
 					if not IsValid(Entity) then return end
 
-					ACF.SendNotify(Owner, false, Name .. " has been disabled: " .. Message)
+					Notify.EntityDisabledToPlayer(Entity, Owner, Name .. " has been disabled", Message)
 				end)
 			else
-				ACF.SendNotify(Owner, false, Name .. " has been disabled: " .. Message)
+				ACF.EntityDisabledToPlayer(Entity, Owner, Name .. " has been disabled", Message)
 			end
 		end
 		-- Send the entity to the client

--- a/lua/acf/damage/permissions/permissions_sv.lua
+++ b/lua/acf/damage/permissions/permissions_sv.lua
@@ -3,6 +3,8 @@ local ACF = ACF
 ACF.Permissions = ACF.Permissions or {}
 local Permissions = ACF.Permissions
 local Messages = ACF.Utilities.Messages
+local Notify   = ACF.Utilities.Notify
+
 --TODO: make player-customizable
 Permissions.Safezones = false
 Permissions.Player = Permissions.Player or {}
@@ -594,12 +596,12 @@ net.Receive("ACF_dmgfriends", function(_, Ply)
 			local Note = Check and "given you" or "removed your"
 			local PlyNick = string.Trim(string.format("%q", Ply:Nick()), "\"") -- Ensuring that the name is Lua safe
 
-			ACF.SendNotify(Target, true, PlyNick .. " has " .. Note .. " permission to damage their objects with ACF!")
+			Notify.NoticeToPlayer(Target, PlyNick .. " has " .. Note .. " permission to damage their objects with ACF!")
 		end
 	end
 
 	local FeedbackMessage = Success and "Successfully updated your ACF damage permissions!" or "Failed to update your ACF damage permissions."
-	ACF.SendNotify(Ply, Success, FeedbackMessage)
+	Notify.NoticeToPlayer(Ply, FeedbackMessage)
 end)
 
 function Permissions.RefreshPlyDPFriends(ply)

--- a/lua/acf/entities/baseplate_types/recreational.lua
+++ b/lua/acf/entities/baseplate_types/recreational.lua
@@ -1,3 +1,4 @@
+local Notify    = ACF.Utilities.Notify
 local Types     = ACF.Classes.BaseplateTypes
 local Baseplate = Types.Register("Recreational")
 local EmptyTable = {}
@@ -14,7 +15,7 @@ function Baseplate:OnLoaded()
 
 		-- Kill ammo
 		for v, _ in pairs(Contraption.Ammo or EmptyTable) do
-			if IsValid(Owner) then ACF.SendNotify(Owner, false, "Recreational Baseplate Used For Combat") end
+			if IsValid(Owner) then Notify.WarningToPlayer(Owner, "Baseplate removed", "A recreational baseplate was used for combat.") end
 			if IsValid(v) then
 				Contraption.Ammo[v] = nil
 				v:Remove()
@@ -23,7 +24,7 @@ function Baseplate:OnLoaded()
 
 		-- Kill weapons
 		for v, _ in pairs(Contraption.Guns or EmptyTable) do
-			if IsValid(Owner) then ACF.SendNotify(Owner, false, "Recreational Baseplate Used For Combat") end
+			if IsValid(Owner) then Notify.WarningToPlayer(Owner, "Baseplate removed", "A recreational baseplate was used for combat.") end
 			if IsValid(v) then
 				Contraption.Guns[v] = nil
 				v:Remove()
@@ -31,7 +32,7 @@ function Baseplate:OnLoaded()
 		end
 
 		for v, _ in pairs(Contraption.Piledrivers or EmptyTable) do
-			if IsValid(Owner) then ACF.SendNotify(Owner, false, "Recreational Baseplate Used For Combat") end
+			if IsValid(Owner) then Notify.WarningToPlayer(Owner, "Baseplate removed", "A recreational baseplate was used for combat.") end
 			if IsValid(v) then
 				Contraption.Piledrivers[v] = nil
 				v:Remove()
@@ -39,7 +40,7 @@ function Baseplate:OnLoaded()
 		end
 
 		for v, _ in pairs(Contraption.Racks or EmptyTable) do
-			if IsValid(Owner) then ACF.SendNotify(Owner, false, "Recreational Baseplate Used For Combat") end
+			if IsValid(Owner) then Notify.WarningToPlayer(Owner, "Baseplate removed", "A recreational baseplate was used for combat.") end
 			if IsValid(v) then
 				Contraption.Racks[v] = nil
 				v:Remove()

--- a/lua/acf/menu/operations/acf_menu.lua
+++ b/lua/acf/menu/operations/acf_menu.lua
@@ -381,15 +381,16 @@ ACF.CreateMenuOperation("2-Motor", "turret motor")
 ACF.CreateMenuOperation("3-Gyro", "turret gyroscope")
 ACF.CreateMenuOperation("4-Computer", "turret computer")
 
+local Notify = ACF.Utilities.Notify
 ACF.CreateMenuOperation("Baseplate", "baseplate", nil, {
 	Text = "Attempts to convert the target entity into a baseplate.",
 	Func = function(Tool, Trace)
 		if CLIENT then return end
 		local success, msg = ACF.ConvertBaseplate(Tool.SWEP:GetOwner(), Trace.Entity)
 		if not success then
-			ACF.SendNotify(Tool:GetOwner(), false, "Could not convert baseplate: " .. msg)
+			Notify.WarningToPlayer(Tool:GetOwner(), "Could not convert baseplate.", msg)
 		else
-			ACF.SendNotify(Tool:GetOwner(), true, "Successfully converted entity to baseplate.")
+			Notify.NoticeToPlayer(Tool:GetOwner(), "Successfully converted entity to baseplate.")
 		end
 	end
 })

--- a/lua/acf/scanner/scanner_sh.lua
+++ b/lua/acf/scanner/scanner_sh.lua
@@ -3,6 +3,7 @@
 -- A lot of this code has been optimized/profiled, but there's more work to do in that department...
 
 local ACF = ACF
+local Notify = ACF.Utilities.Notify
 
 if ACF.Scanning and ACF.Scanning.ClearPanels and CLIENT then
     ACF.Scanning.ClearPanels()
@@ -238,7 +239,7 @@ if SERVER then
                         msg = "ACF damage is currently blocked due to recent use of the contraption scanner. Please try again in " .. math.Round(scanner_damageCooldown - (now - started), 2) .. " seconds."
                     end
 
-                    ACF.SendNotify(owner, false, msg)
+                    Notify.WarningToPlayer(owner, msg)
                 end
                 scanner_acfDamage_notifiedThisTick[owner] = true
                 return false

--- a/lua/cfw/extensions/acf_extensions_sv.lua
+++ b/lua/cfw/extensions/acf_extensions_sv.lua
@@ -1,3 +1,5 @@
+local Notify = ACF.Utilities.Notify
+
 -- Track ACF changes on a contraption
 do
     -- Maintain a record in the contraption of its current baseplate
@@ -14,7 +16,8 @@ do
             -- scenario since there's still only one baseplate. Maybe this is too paranoid.
             if IsValid(contraption.ACF_Baseplate) and ent ~= contraption.ACF_Baseplate then
                 -- Destroy the new one! We can't have more than one on a contraption
-                ACF.SendNotify(ent:CPPIGetOwner(), false, "A contraption can only have one ACF baseplate. New baseplate removed.")
+                -- Warn on the baseplate that won't be destroyed... otherwise not really a point to using EntityWarning
+                Notify.EntityWarning(contraption.ACF_Baseplate, "A contraption can only have one ACF baseplate. New baseplate removed.")
                 ent:Remove()
                 return
             end

--- a/lua/entities/acf_ammo/modules/spawning.lua
+++ b/lua/entities/acf_ammo/modules/spawning.lua
@@ -2,6 +2,7 @@ local ACF          = ACF
 local Classes      = ACF.Classes
 local Utilities    = ACF.Utilities
 local WireIO       = Utilities.WireIO
+local Notify       = Utilities.Notify
 local WireLib      = WireLib
 local Entities     = Classes.Entities
 local AmmoTypes    = Classes.AmmoTypes
@@ -365,7 +366,7 @@ do -- Spawn/Update/Remove
 			end
 
 			if Unloaded then
-				ACF.SendNotify(Entity.Owner, false, "Crate updated while weapons were loaded with its ammo. Weapons unloaded.")
+				Notify.EntityWarning(Entity, "Weapons unloaded.", "Crate updated while weapons were loaded with its ammo")
 			end
 		end
 

--- a/lua/entities/acf_baseplate/modules/spawning.lua
+++ b/lua/entities/acf_baseplate/modules/spawning.lua
@@ -1,5 +1,5 @@
 local ACF      		= ACF
-
+local Notify        = ACF.Utilities.Notify
 function ENT.ACF_OnVerifyClientData(ClientData)
 	ClientData.Size = Vector(ClientData.Length, ClientData.Width, ClientData.Thickness)
 	if ClientData.BaseplateType ~= "Aircraft" then ClientData.GForceTicks = 1 end -- Only allow sample rates > 1 for aircraft baseplates
@@ -81,7 +81,7 @@ function ENT:PostEntityPaste(_, _, CreatedEntities)
 	if LuaSeatID then
 		self.Pod = CreatedEntities[LuaSeatID]
 		if not IsValid(self.Pod) then
-			ACF.SendNotify(self:CPPIGetOwner(), false, "The baseplate pod did not get duplicated correctly. You may have to relink pod controllers, etc.")
+			Notify.EntityWarning(self, "The baseplate pod did not get duplicated correctly", "You may have to relink pod controllers, etc.")
 			local Pod = ACF.GenerateLuaSeat(self, self:CPPIGetOwner(), self:GetPos(), self:GetAngles(), self:GetModel(), true)
 			if IsValid(Pod) then self.Pod = Pod end
 		end

--- a/lua/entities/acf_baseplate/modules/state.lua
+++ b/lua/entities/acf_baseplate/modules/state.lua
@@ -1,11 +1,9 @@
 local ACF      		= ACF
+local Notify        = ACF.Utilities.Notify
 
 function ENT:CFW_PreParentedTo(_, NewEntity)
 	if IsValid(NewEntity) then
-		local Owner = self:CPPIGetOwner()
-		if IsValid(Owner) then
-			ACF.SendNotify(Owner, false, "Cannot parent an ACF baseplate to another entity.")
-		end
+		Notify.EntityWarning(self, "Cannot parent an ACF baseplate to another entity", "Baseplates are expected to be the root ancestor of a contraption, and parenting them would break that guarantee.")
 	end
 
 	return false

--- a/lua/entities/acf_crew/init.lua
+++ b/lua/entities/acf_crew/init.lua
@@ -35,6 +35,7 @@ include("shared.lua")
 local ACF = ACF
 local HookRun     = hook.Run
 local Utilities   = ACF.Utilities
+local Notify      = Utilities.Notify
 local WireIO      = Utilities.WireIO
 
 local Contraption = ACF.Contraption
@@ -141,7 +142,7 @@ end
 function ENT:CFW_PreParentedTo(OldParent, _)
 	-- Force unlinks if OldParent is valid
 	if IsValid(OldParent) and not self:IsMarkedForDeletion() then
-		ACF.SendNotify(self:CPPIGetOwner(), false, "Crew parent has changed from a previously valid parent. All links removed, please relink.")
+		Notify.EntityWarning(self, "Crew parent has changed", "This crew member was reparented. All links have been removed, please relink.")
 		if next(self.Targets) then
 			for Target in pairs(self.Targets) do
 				self:Unlink(Target)
@@ -180,7 +181,7 @@ local function EnforceLimits(crew)
 		local Count = Crews and table.Count(Crews) or 0
 
 		if Count > Limit.Amount then
-			ACF.SendNotify(crew:GetOwner(), false, "You have reached the " .. CrewType.Name .. " limit for this Contraption.")
+			Notify.WarningToPlayer(crew:CPPIGetOwner(), "You have reached the " .. CrewType.Name .. " limit for this Contraption.")
 			crew:Remove()
 		end
 	end
@@ -303,7 +304,7 @@ do -- Random timer stuff
 					Reasons = table.concat(Reasons, ", and ")
 					Reasons = string.upper(Reasons[1]) .. string.sub(Reasons, 2)
 
-					ACF.SendNotify(self:CPPIGetOwner(), false, "Crew #" .. self:EntIndex() .. " unlinked. " .. Reasons)
+					Notify.EntityWarning(self, "Crew member unlinked. ", Reasons)
 				end
 			end
 		end
@@ -575,7 +576,7 @@ do
 
 		-- Unlink crews if their type changes
 		if self.CrewTypeID ~= Data.CrewTypeID then
-			ACF.SendNotify(self:GetOwner(), false, "Crew updated with different occupation. All links removed, please relink.")
+			Notify.EntityWarning(self, "Crew occupation has changed", "This crew member's occupation was changed. All links have been removed, please relink.")
 			if next(self.Targets) then
 				for Target in pairs(self.Targets) do
 					self:Unlink(Target)
@@ -1024,7 +1025,7 @@ do
 			for _, EntID in pairs(EntMods.CrewTargets) do
 				local ActualEnt = CreatedEntities[EntID]
 				local result, err = self:Link(ActualEnt)
-				if not result then ACF.SendNotify(Ent:CPPIGetOwner(), false, "ACF Crew:PostEntityPaste failure: " .. err) end
+				if not result then Notify.EntityWarning(Ent, "ACF Crew:PostEntityPaste failure", err) end
 			end
 
 			self.RemainingLinks = RLs

--- a/lua/entities/acf_gearbox/init.lua
+++ b/lua/entities/acf_gearbox/init.lua
@@ -11,6 +11,7 @@ local Mobility    = ACF.Mobility
 local MobilityObj = Mobility.Objects
 local Utilities   = ACF.Utilities
 local Clock       = Utilities.Clock
+local Notify      = Utilities.Notify
 local Clamp       = math.Clamp
 local abs         = math.abs
 local min         = math.min
@@ -234,13 +235,13 @@ do -- Spawn and Update functions -----------------------
 			-- make sure it is not stretched too far
 			if OutPos:Distance(InPos) > Link.RopeLen * 1.5 then
 				Entity:Unlink(Ent)
-				ACF.SendNotify(Ent:CPPIGetOwner(), false, "Gearbox -> " .. NiceName .. " connection broken; excessive distance!")
+				Notify.EntityWarning(Ent, "Gearbox to " .. NiceName .. " connection broken", "Excessive distance!")
 				continue
 			end
 
 			if ACF.IsDriveshaftAngleExcessive(Ent, Ent.In, Link) then
 				Entity:Unlink(Ent)
-				ACF.SendNotify(Ent:CPPIGetOwner(), false, "Gearbox -> " .. NiceName .. " connection broken; excessive driveshaft angle!")
+				Notify.EntityWarning(Ent, "Gearbox to " .. NiceName .. " connection broken", "Excessive driveshaft angle!")
 				continue
 			end
 
@@ -254,7 +255,7 @@ do -- Spawn and Update functions -----------------------
 				local Stress = math.max(WheelPhys:GetStress())
 				if Stress > 15 then
 					Entity:Unlink(Ent)
-					ACF.SendNotify(Ent:CPPIGetOwner(), false, "Gearbox -> " .. NiceName .. " connection broken; excessive stress on connected + on an aircraft contraption!")
+					Notify.EntityWarning(Ent, "Gearbox to " .. NiceName .. " connection broken", "Excess stress on linked props!\n(aircraft baseplates cannot have wheel-like gearbox connections)")
 					continue
 				end
 			end

--- a/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
@@ -389,7 +389,7 @@ e2function number entity:acfUnlinkFrom(entity Target, number Notify)
 
 	if not this.Unlink then
 		if Notify ~= 0 then
-			Notify.EntityWarningToPlayer(Target, self.player, 0, "This entity is not linkable.")
+			Notify.EntityWarningToPlayer(Target, self.player, "This entity is not linkable.")
 		end
 
 		return 0

--- a/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
@@ -14,6 +14,7 @@ E2Lib.RegisterExtension("acf", true)
 local ACF       = ACF
 local AmmoTypes = ACF.Classes.AmmoTypes
 local Clock     = ACF.Utilities.Clock
+local Notify    = ACF.Utilities.Notify
 local match     = string.match
 local floor     = math.floor
 local Round     = math.Round
@@ -337,7 +338,7 @@ end
 e2function number entity:acfLinkTo(entity Target, number Notify)
 	if not ACF.AllowDynamicLinking then
 		if Notify ~= 0 then
-			ACF.SendNotify(self.player, 0, "Dynamic linking has been disabled on this server.")
+			Notify.EntityWarningToPlayer(Target, self.player, "Dynamic linking has been disabled on this server.")
 		end
 
 		return 0
@@ -347,7 +348,7 @@ e2function number entity:acfLinkTo(entity Target, number Notify)
 	if not validPhysics(Target) then return 0 end
 	if not (isOwner(self, this) and isOwner(self, Target)) then
 		if Notify ~= 0 then
-			ACF.SendNotify(self.player, 0, "Must be called on entities you own.")
+			Notify.EntityWarningToPlayer(Target, self.player, "Must be called on entities you own.")
 		end
 
 		return 0
@@ -355,7 +356,7 @@ e2function number entity:acfLinkTo(entity Target, number Notify)
 
 	if not this.Link then
 		if Notify ~= 0 then
-			ACF.SendNotify(self.player, 0, "This entity is not linkable.")
+			Notify.EntityWarningToPlayer(Target, self.player, "This entity is not linkable.")
 		end
 
 		return 0
@@ -364,7 +365,11 @@ e2function number entity:acfLinkTo(entity Target, number Notify)
 	local Success, Message = this:Link(Target, true)
 
 	if Notify ~= 0 then
-		ACF.SendNotify(self.player, Success, Message)
+		if Success then
+			Notify.EntityNoticeToPlayer(Target, self.player, Message)
+		else
+			Notify.EntityWarningToPlayer(Target, self.player, Message)
+		end
 	end
 
 	return Success and 1 or 0
@@ -376,7 +381,7 @@ e2function number entity:acfUnlinkFrom(entity Target, number Notify)
 	if not validPhysics(Target) then return 0 end
 	if not (isOwner(self, this) and isOwner(self, Target)) then
 		if Notify ~= 0 then
-			ACF.SendNotify(self.player, 0, "Must be called on entities you own.")
+			Notify.EntityWarningToPlayer(Target, self.player, "Must be called on entities you own.")
 		end
 
 		return 0
@@ -384,7 +389,7 @@ e2function number entity:acfUnlinkFrom(entity Target, number Notify)
 
 	if not this.Unlink then
 		if Notify ~= 0 then
-			ACF.SendNotify(self.player, 0, "This entity is not linkable.")
+			Notify.EntityWarningToPlayer(Target, self.player, 0, "This entity is not linkable.")
 		end
 
 		return 0
@@ -393,7 +398,11 @@ e2function number entity:acfUnlinkFrom(entity Target, number Notify)
 	local Success, Message = this:Unlink(Target)
 
 	if Notify > 0 then
-		ACF.SendNotify(self.player, Success, Message)
+		if Success then
+			Notify.EntityNoticeToPlayer(Target, self.player, Message)
+		else
+			Notify.EntityWarningToPlayer(Target, self.player, Message)
+		end
 	end
 
 	return Success and 1 or 0

--- a/lua/starfall/libs_sh/acffunctions.lua
+++ b/lua/starfall/libs_sh/acffunctions.lua
@@ -30,6 +30,7 @@ local FuelTypes         = Classes.FuelTypes
 local Gearboxes         = Classes.Gearboxes
 local Weapons           = Classes.Weapons
 local Clock             = ACF.Utilities.Clock
+local Notify            = ACF.Utilities.Notify
 local CheckLuaType      = SF.CheckLuaType
 local CheckPerms        = SF.Permissions.check
 local RegisterPrivilege = SF.Permissions.registerPrivilege
@@ -1017,7 +1018,7 @@ if SERVER then
 	function ents_methods:acfLinkTo(target, notify)
 		if not ACF.AllowDynamicLinking then
 			if notify then
-				ACF.SendNotify(instance.player, false, "Dynamic linking has been disabled on this server.")
+				Notify.EntityWarningToPlayer(unwrap(target), instance.player, "Dynamic linking has been disabled on this server.")
 			end
 
 			return false, "Dynamic linking has been disabled on this server."
@@ -1042,7 +1043,11 @@ if SERVER then
 		local Success, Message = This:Link(Target, true)
 
 		if notify then
-			ACF.SendNotify(instance.player, Success, Message)
+			if Success then
+				Notify.EntityNoticeToPlayer(Target, instance.player, Message)
+			else
+				Notify.EntityWarningToPlayer(Target, instance.player, Message)
+			end
 		end
 
 		return Success, Message
@@ -1071,7 +1076,11 @@ if SERVER then
 		local Success, Message = This:Unlink(Target)
 
 		if notify then
-			ACF.SendNotify(instance.player, Success, Message)
+			if Success then
+				Notify.EntityNoticeToPlayer(Target, instance.player, Message)
+			else
+				Notify.EntityWarningToPlayer(Target, instance.player, Message)
+			end
 		end
 
 		return Success, Message

--- a/lua/weapons/gmod_tool/stools/acfsound.lua
+++ b/lua/weapons/gmod_tool/stools/acfsound.lua
@@ -41,9 +41,9 @@ local function IsReallyValid(trace, ply)
 
 	if not ACF.SoundToolSupport[class] then
 		if SERVER and string.StartWith(class, "acf_") then
-			ACF.SendNotify(ply, false, "#tool.acfsound.unsupported_class")
+			Notify.EntityWarningToPlayer(trace.Entity, ply, "#tool.acfsound.unsupported_class")
 		elseif SERVER then
-			ACF.SendNotify(ply, false, "#tool.acfsound.unsupported_ent")
+			Notify.EntityWarningToPlayer(trace.Entity, ply, "#tool.acfsound.unsupported_ent")
 		end
 
 		return false

--- a/lua/weapons/gmod_tool/stools/acfsuspension.lua
+++ b/lua/weapons/gmod_tool/stools/acfsuspension.lua
@@ -5,6 +5,7 @@ Notes:
 --]]
 
 local ACF = ACF
+local Notify = ACF.Utilities.Notify
 local IsValid = IsValid
 
 TOOL.Category	 = (ACF.CustomToolCategory and ACF.CustomToolCategory:GetBool()) and "ACF" or "Construction"
@@ -215,7 +216,7 @@ elseif SERVER then -- Serverside-only stuff
 		else
 			-- Select a wheel for the plate
 			if #self.Selections.Plates == 0 then
-				ACF.SendNotify(Player, false, "You need to select a baseplate first.")
+				Notify.WarningToPlayer(Player, "You need to select a baseplate first.")
 				return
 			end
 
@@ -409,11 +410,12 @@ elseif SERVER then -- Serverside-only stuff
 		local ControlPlate = Selections.ControlPlate
 
 		-- Cover edge cases
-		if not IsValid(Baseplate) then ACF.SendNotify(Player, false, "Drivetrain could not be created: Baseplate missing.") return end
-		if IsValid(Baseplate:GetParent()) then ACF.SendNotify(Player, false, "Drivetrain could not be created: Cannot use a parented entity as a baseplate.") return end
-		if SpringType == 2 and not IsValid(ControlPlate) then ACF.SendNotify(Player, false, "Drivetrain could not be created: Control plate missing.") return end
+		if not IsValid(Baseplate) then Notify.WarningToPlayer(Player, "Drivetrain could not be created", "Baseplate missing.") return end
+		if IsValid(Baseplate:GetParent()) then Notify.EntityWarningToPlayer(Baseplate, Player, "Drivetrain could not be created", "Cannot use a parented entity as a baseplate.") return end
+		if SpringType == 2 and not IsValid(ControlPlate) then Notify.WarningToPlayer(Player, "Drivetrain could not be created", "Control plate missing.") return end
 		for Wheel, _ in pairs(Selections.Wheels or EmptyTable) do
-			if IsValid(Wheel:GetParent()) then ACF.SendNotify(Player, false, "Drivetrain could not be created: Cannot use a parented entity as a wheel.") end
+			-- MARCH: Shouldn't this return if this is the case...? Going to add it now in new-notifications to not miss it, but let me know if this was intentional
+			if IsValid(Wheel:GetParent()) then Notify.EntityWarningToPlayer(Wheel, Player, "Drivetrain could not be created", "Cannot use a parented entity as a wheel.") return end
 		end
 
 		-- Handle makespherical / disable collisions BEFORE making the constraints
@@ -469,7 +471,7 @@ elseif SERVER then -- Serverside-only stuff
 				else
 					local Deviation = math.deg(math.acos(Plate:GetForward():Dot(Vector(0, 1, 0))))
 					if Deviation > 0.05 then
-						ACF.SendNotify(Player, false, "Drivetrain could not be created: Plate [" .. tostring(Plate) .. "] must be facing north. Deviation [" .. tostring(math.Round(Deviation, 2)) .. "].")
+						Notify.EntityWarningToPlayer(Plate, Player, "Drivetrain could not be created", "Plate [" .. tostring(Plate) .. "] must be facing north\nDeviation [" .. tostring(math.Round(Deviation, 2)) .. "].")
 						return
 					end
 					HullSocket(Wheel, Plate) -- Restrict rotation to baseplate or steer plate
@@ -489,7 +491,7 @@ elseif SERVER then -- Serverside-only stuff
 			end
 		end
 
-		ACF.SendNotify(Player, true, "Drivetrain successfully created.")
+		Notify.NoticeToPlayer(Player, "Drivetrain successfully created.")
 	end
 
 	function TOOL:ClearSuspension()
@@ -505,6 +507,6 @@ elseif SERVER then -- Serverside-only stuff
 			if IsValid(v) and checkOwner(Player, v) then constraint.RemoveAll(v) end
 		end
 
-		ACF.SendNotify(Player, true, "Cleared all constraints in drivetrain")
+		Notify.NoticeToPlayer(Player, "Cleared all constraints in drivetrain")
 	end
 end


### PR DESCRIPTION
This redoes how ACF sends notifications. The API now uses builder structure for the low level aspects, with a custom notification handler that allows for
- Sounds w/ rate limiting
- Buttons w/ clientside actions
- Custom notification icons

The higher-level API is very similar to previous SendNotify calls. There is now:
- Notify.EntityDisabledToPlayer(Ent, Player, Reason, Ponder, WikiArticle)
- Notify.WarningToPlayer(Player, Title, Description, Ponder, WikiArticle)
- Notify.EntityWarningToPlayer(Ent, Player, Title, Description, Ponder, WikiArticle)
- Notify.EntityWarning(Ent, Title, Description, Ponder, WikiArticle)
- Notify.NoticeToPlayer(Player, Title, Description, Ponder, WikiArticle)
- Notify.EntityNoticeToPlayer(Ent, Player, Title, Description, Ponder, WikiArticle)
- Notify.EntityNotice(Ent, Title, Description, Ponder, WikiArticle)
We can add new things to the higher-level API very easily since it utilizes the builder structure API under the hood.

The library can be called from the server realm or the client realm. In the case of the client realm, the recipient filter is ignored. But the API is the same across realms otherwise.