### PR TITLE
Fix entity paste error ambiguity

### DIFF
--- a/lua/acf/core/classes/entities/registration.lua
+++ b/lua/acf/core/classes/entities/registration.lua
@@ -984,7 +984,11 @@ function Entities.AutoRegister(ENT)
 			end
 		end
 
-		local _, SpawnedEntity = Entities.Spawn(Class, Player, Pos, Angle, UserData, true)
+		local success, SpawnedEntity = Entities.Spawn(Class, Player, Pos, Angle, UserData, true)
+		if not success then
+			ErrorNoHaltWithStack(SpawnedEntity)
+			return
+		end
 
 		if ShouldTransferLegacyData then
 			for _, KeyName in ipairs(ReadKeys) do


### PR DESCRIPTION
Fixes the function to throw an error with the actual reason rather than failing with
`attempt to index local 'SpawnedEntity' (a string value)` 