### PR TITLE
Missile rebalancing + bugfixes

### DIFF
--- a/lua/acf/core/globals.lua
+++ b/lua/acf/core/globals.lua
@@ -200,7 +200,7 @@ do -- ACF global vars
 	ACF.LToGal               = 0.264172 -- Liters to gallons
 
 	-- Fuzes
-	ACF.MinFuzeCaliber       = 20 -- Minimum caliber in millimeters that can be fuzed
+	ACF.MinFuzeCaliber       = 25 -- Minimum caliber in millimeters that can be fuzed
 
 	-- Reload Mechanics
 	ACF.BaseReload         = 1 -- Minimum reload time. Time it takes to move around a weightless projectile

--- a/lua/acf/entities/ammo_types/aphe.lua
+++ b/lua/acf/entities/ammo_types/aphe.lua
@@ -71,7 +71,7 @@ function Ammo:BaseConvert(ToolData)
 	Data.ShovePower = 0.1
 	Data.LimitVel   = 700 --Most efficient penetration speed in m/s
 	Data.Ricochet   = 65 --Base ricochet angle
-	Data.CanFuze    = Data.Caliber * 10 >= ACF.MinFuzeCaliber -- Can fuze on calibers > 20mm
+	Data.CanFuze    = Data.Caliber * 10 >= ACF.MinFuzeCaliber -- Can fuze on calibers >= 25mm
 
 	GUIData.MinFillerVol = 0
 

--- a/lua/acf/entities/ammo_types/fl.lua
+++ b/lua/acf/entities/ammo_types/fl.lua
@@ -78,7 +78,7 @@ function Ammo:BaseConvert(ToolData)
 
 	Data.MaxFlechettes = math.Clamp(math.floor(Data.Caliber * 4), 12, 64)
 	Data.MinFlechettes = math.min(12, Data.MaxFlechettes) --force bigger guns to have higher min count
-	Data.MinSpread	   = 1
+	Data.MinSpread	   = 0.2
 	Data.MaxSpread	   = 10
 	Data.ShovePower	   = 0.2
 	Data.LimitVel	   = 500 --Most efficient penetration speed in m/s

--- a/lua/acf/entities/ammo_types/he.lua
+++ b/lua/acf/entities/ammo_types/he.lua
@@ -66,7 +66,7 @@ function Ammo:BaseConvert(ToolData)
 	Data.LimitVel		= 100 --Most efficient penetration speed in m/s
 	Data.Ricochet		= 60 --Base ricochet angle
 	Data.DetonatorAngle	= 80
-	Data.CanFuze		= Data.Caliber * 10 >= ACF.MinFuzeCaliber -- Can fuze on calibers > 20mm
+	Data.CanFuze		= Data.Caliber * 10 >= ACF.MinFuzeCaliber -- Can fuze on calibers >= 25mm
 
 	self:UpdateRoundData(ToolData, Data, GUIData)
 

--- a/lua/acf/entities/ammo_types/heat.lua
+++ b/lua/acf/entities/ammo_types/heat.lua
@@ -183,7 +183,7 @@ function Ammo:BaseConvert(ToolData)
 	Data.LimitVel		= 100 -- Most efficient penetration speed in m/s
 	Data.Ricochet		= 60 -- Base ricochet angle
 	Data.DetonatorAngle	= 75
-	Data.CanFuze		= Data.Caliber * 10 >= ACF.MinFuzeCaliber -- Can fuze on calibers > 20mm
+	Data.CanFuze		= Data.Caliber * 10 >= ACF.MinFuzeCaliber -- Can fuze on calibers >= 25mm
 
 	self:UpdateRoundData(ToolData, Data, GUIData)
 

--- a/lua/acf/entities/ammo_types/smoke.lua
+++ b/lua/acf/entities/ammo_types/smoke.lua
@@ -83,7 +83,7 @@ function Ammo:BaseConvert(ToolData)
 	Data.LimitVel		= 100 --Most efficient penetration speed in m/s
 	Data.Ricochet		= 60 --Base ricochet angle
 	Data.DetonatorAngle	= 80
-	Data.CanFuze		= Data.Caliber * 10 >= ACF.MinFuzeCaliber -- Can fuze on calibers > 20mm
+	Data.CanFuze		= Data.Caliber * 10 >= ACF.MinFuzeCaliber -- Can fuze on calibers >= 25mm
 
 	self:UpdateRoundData(ToolData, Data, GUIData)
 

--- a/lua/acf/entities/missiles/aam.lua
+++ b/lua/acf/entities/missiles/aam.lua
@@ -37,7 +37,7 @@ Missiles.RegisterItem("AIM-9 AAM", "AAM", {
 		Model           = "models/missiles/aim9m.mdl",
 		MaxLength       = 289,
 		ProjLength      = 68,
-		Armor           = 2,
+		Armor           = 1,
 		PropLength      = 160,
 		Thrust          = 800000, -- in kg*in/s^2
 		FuelConsumption = 0.02, -- in g/s/f
@@ -79,7 +79,7 @@ Missiles.RegisterItem("AIM-120 AAM", "AAM", {
 	Round = {
 		Model           = "models/missiles/aim120c.mdl",
 		MaxLength       = 370,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 70,
 		PropLength      = 200,
 		Thrust          = 1500000, -- in kg*in/s^2
@@ -122,7 +122,7 @@ Missiles.RegisterItem("AIM-7 AAM", "AAM", {
 	Round = {
 		Model           = "models/missiles/aim7f.mdl",
 		MaxLength       = 370,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 70,
 		PropLength      = 200,
 		Thrust          = 3000000, -- in kg*in/s^2
@@ -165,7 +165,7 @@ Missiles.RegisterItem("AIM-54 AAM", "AAM", {
 	Round = {
 		Model           = "models/missiles/aim54a.mdl",
 		MaxLength       = 400,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 60,
 		PropLength      = 220,
 		Thrust          = 4000000, -- in kg*in/s^2

--- a/lua/acf/entities/missiles/arm.lua
+++ b/lua/acf/entities/missiles/arm.lua
@@ -37,7 +37,7 @@ Missiles.RegisterItem("AGM-122 ASM", "ARM", {
 	Round = {
 		Model           = "models/missiles/aim9.mdl",
 		MaxLength       = 287,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 68,
 		PropLength      = 160,
 		Thrust          = 800000, -- in kg*in/s^2
@@ -79,7 +79,7 @@ Missiles.RegisterItem("AGM-45 ASM", "ARM", {
 	Round = {
 		Model           = "models/missiles/aim120.mdl",
 		MaxLength       = 305,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 70,
 		PropLength      = 200,
 		Thrust          = 1500000, -- in kg*in/s^2

--- a/lua/acf/entities/missiles/arty.lua
+++ b/lua/acf/entities/missiles/arty.lua
@@ -34,7 +34,7 @@ Missiles.RegisterItem("Type 63 RA", "ARTY", {
 	Round = {
 		Model           = "models/missiles/glatgm/mgm51.mdl",
 		MaxLength       = 80,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 35,
 		PropLength      = 45,
 		Thrust          = 5000, -- in kg*in/s^2
@@ -77,7 +77,7 @@ Missiles.RegisterItem("SAKR-10 RA", "ARTY", {
 		Model           = "models/missiles/hvar_folded.mdl",
 		RackModel       = "models/missiles/hvar_folded.mdl",
 		MaxLength       = 287,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 100,
 		PropLength      = 160,
 		Thrust          = 800000, -- in kg*in/s^2
@@ -120,7 +120,7 @@ Missiles.RegisterItem("SS-40 RA", "ARTY", {
 		Model           = "models/missiles/hvar_folded.mdl",
 		RackModel       = "models/missiles/hvar_folded.mdl",
 		MaxLength       = 370,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 140,
 		PropLength      = 200,
 		Thrust          = 2400000, -- in kg*in/s^2

--- a/lua/acf/entities/missiles/asm.lua
+++ b/lua/acf/entities/missiles/asm.lua
@@ -35,7 +35,7 @@ Missiles.RegisterItem("AT-3 ASM", "ATGM", {
 	Round = {
 		Model           = "models/missiles/at3.mdl",
 		MaxLength       = 86,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 16,
 		PropLength      = 26,
 		Thrust          = 8020, -- in kg*in/s^2
@@ -79,7 +79,7 @@ Missiles.RegisterItem("BGM-71E ASM", "ATGM", {
 		Model           = "models/missiles/bgm_71e.mdl",
 		RackModel       = "models/missiles/bgm_71e_round.mdl",
 		MaxLength       = 117,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 20,
 		PropLength      = 18,
 		Thrust          = 34000, -- in kg*in/s^2
@@ -137,7 +137,7 @@ Missiles.RegisterItem("AGM-114 ASM", "ATGM", {
 	Round = {
 		Model           = "models/missiles/agm_114.mdl",
 		MaxLength       = 160,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 30,
 		PropLength      = 56,
 		Thrust          = 210000, -- in kg*in/s^2
@@ -185,7 +185,7 @@ Missiles.RegisterItem("Ataka ASM", "ATGM", {
 		Model           = "models/missiles/9m120.mdl",
 		RackModel       = "models/missiles/9m120_rk1.mdl",
 		MaxLength       = 183,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 17.5,
 		PropLength      = 68,
 		Thrust          = 230000, -- in kg*in/s^2
@@ -241,7 +241,7 @@ Missiles.RegisterItem("9M133 ASM", "ATGM", {
 		Model           = "models/kali/weapons/kornet/parts/9m133 kornet missile.mdl",
 		RackModel       = "models/kali/weapons/kornet/parts/9m133 kornet tube.mdl",
 		MaxLength       = 120,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 21,
 		PropLength      = 30,
 		Thrust          = 40000,   -- in kg*in/s^2
@@ -289,7 +289,7 @@ Missiles.RegisterItem("AT-2 ASM", "ATGM", {
 	Round = {
 		Model           = "models/missiles/at2.mdl",
 		MaxLength       = 116,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 23,
 		PropLength      = 26,
 		Thrust          = 68000, -- in kg*in/s^2

--- a/lua/acf/entities/missiles/bomb.lua
+++ b/lua/acf/entities/missiles/bomb.lua
@@ -34,7 +34,7 @@ Missiles.RegisterItem("50kgBOMB", "BOMB", {
 	Round = {
 		Model           = "models/bombs/fab50.mdl",
 		MaxLength       = 109,
-		Armor           = 5,
+		Armor           = 1,
 		ProjLength      = 50,
 		PropLength      = 0,
 		Thrust          = 1, -- in kg*in/s^2
@@ -75,7 +75,7 @@ Missiles.RegisterItem("100kgBOMB", "BOMB", {
 	Round = {
 		Model           = "models/bombs/fab100.mdl",
 		MaxLength       = 106,
-		Armor           = 5,
+		Armor           = 2,
 		ProjLength      = 55,
 		PropLength      = 0,
 		Thrust          = 1, -- in kg*in/s^2
@@ -116,7 +116,7 @@ Missiles.RegisterItem("250kgBOMB", "BOMB", {
 	Round = {
 		Model           = "models/bombs/fab250.mdl",
 		MaxLength       = 145,
-		Armor           = 5,
+		Armor           = 2,
 		ProjLength      = 100,
 		PropLength      = 0,
 		Thrust          = 1, -- in kg*in/s^2
@@ -157,7 +157,7 @@ Missiles.RegisterItem("500kgBOMB", "BOMB", {
 	Round = {
 		Model           = "models/bombs/fab500.mdl",
 		MaxLength       = 240,
-		Armor           = 5,
+		Armor           = 3,
 		ProjLength      = 130,
 		PropLength      = 0,
 		Thrust          = 1, -- in kg*in/s^2
@@ -198,7 +198,7 @@ Missiles.RegisterItem("1000kgBOMB", "BOMB", {
 	Round = {
 		Model           = "models/bombs/an_m66.mdl",
 		MaxLength       = 270,
-		Armor           = 5,
+		Armor           = 3,
 		ProjLength      = 190,
 		PropLength      = 0,
 		Thrust          = 1, -- in kg*in/s^2

--- a/lua/acf/entities/missiles/ffar.lua
+++ b/lua/acf/entities/missiles/ffar.lua
@@ -34,7 +34,7 @@ Missiles.RegisterItem("40mmFFAR", "FFAR", {
 		Model           = "models/missiles/ffar_40mm.mdl",
 		RackModel       = "models/missiles/ffar_40mm_closed.mdl",
 		MaxLength       = 60,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 25,
 		PropLength      = 35,
 		Thrust          = 150000, -- in kg*in/s^2
@@ -75,7 +75,7 @@ Missiles.RegisterItem("57mmFFAR", "FFAR", {
 		Model           = "models/missiles/ffar_70mm.mdl",
 		RackModel       = "models/missiles/ffar_70mm_closed.mdl",
 		MaxLength       = 85,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 35,
 		PropLength      = 50,
 		Thrust          = 113000, -- in kg*in/s^2
@@ -116,7 +116,7 @@ Missiles.RegisterItem("70mmFFAR", "FFAR", {
 		Model           = "models/missiles/ffar_70mm.mdl",
 		RackModel       = "models/missiles/ffar_70mm_closed.mdl",
 		MaxLength       = 106,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 66,
 		PropLength      = 40,
 		Thrust          = 128500, -- in kg*in/s^2 -- Why was old thrust 1565m/s
@@ -157,7 +157,7 @@ Missiles.RegisterItem("80mmFFAR", "FFAR", {
 		Model           = "models/missiles/ffar_70mm.mdl",
 		RackModel       = "models/missiles/ffar_70mm_closed.mdl",
 		MaxLength       = 127,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 76,
 		PropLength      = 51,
 		Thrust          = 290000, -- in kg*in/s^2
@@ -198,7 +198,7 @@ Missiles.RegisterItem("Zuni ASR", "FFAR", {
 		Model           = "models/ghosteh/zuni.mdl",
 		RackModel       = "models/ghosteh/zuni_folded.mdl",
 		MaxLength       = 200,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 90,
 		PropLength      = 110,
 		Thrust          = 663000, -- in kg*in/s^2

--- a/lua/acf/entities/missiles/gbomb.lua
+++ b/lua/acf/entities/missiles/gbomb.lua
@@ -32,7 +32,7 @@ Missiles.RegisterItem("100kgGBOMB", "GBOMB", {
 	Round = {
 		Model           = "models/missiles/micro.mdl",
 		MaxLength       = 100,
-		Armor           = 5,
+		Armor           = 2,
 		ProjLength      = 65,
 		PropLength      = 0,
 		Thrust          = 1, -- in kg*in/s^2
@@ -71,7 +71,7 @@ Missiles.RegisterItem("250kgGBOMB", "GBOMB", {
 	Round = {
 		Model           = "models/missiles/fab250.mdl",
 		MaxLength       = 150,
-		Armor           = 5,
+		Armor           = 2,
 		ProjLength      = 100,
 		PropLength      = 0,
 		Thrust          = 1, -- in kg*in/s^2

--- a/lua/acf/entities/missiles/gbu.lua
+++ b/lua/acf/entities/missiles/gbu.lua
@@ -35,7 +35,7 @@ Missiles.RegisterItem("WalleyeGBU", "GBU", {
 	Round = {
 		Model           = "models/bombs/gbu/agm62.mdl",
 		MaxLength       = 345,
-		Armor           = 5,
+		Armor           = 2,
 		ProjLength      = 155,
 		PropLength      = 0,
 		Thrust          = 1, -- in kg*in/s^2
@@ -94,7 +94,7 @@ Missiles.RegisterItem("227kgGBU", "GBU", {
 		Model           = "models/bombs/gbu/gbu12_fold.mdl",
 		RackModel       = "models/bombs/gbu/gbu12.mdl",
 		MaxLength       = 220,
-		Armor           = 5,
+		Armor           = 2,
 		ProjLength      = 155,
 		PropLength      = 0,
 		Thrust          = 1, -- in kg*in/s^2
@@ -153,7 +153,7 @@ Missiles.RegisterItem("454kgGBU", "GBU", {
 		Model           = "models/bombs/gbu/gbu16_fold.mdl",
 		RackModel       = "models/bombs/gbu/gbu16.mdl",
 		MaxLength       = 250,
-		Armor           = 5,
+		Armor           = 2,
 		ProjLength      = 170,
 		PropLength      = 0,
 		Thrust          = 1, -- in kg*in/s^2
@@ -212,7 +212,7 @@ Missiles.RegisterItem("909kgGBU", "GBU", {
 		Model           = "models/bombs/gbu/gbu10_fold.mdl",
 		RackModel       = "models/bombs/gbu/gbu10.mdl",
 		MaxLength       = 320,
-		Armor           = 5,
+		Armor           = 2,
 		ProjLength      = 205,
 		PropLength      = 0,
 		Thrust          = 1, -- in kg*in/s^2

--- a/lua/acf/entities/missiles/sam.lua
+++ b/lua/acf/entities/missiles/sam.lua
@@ -36,7 +36,7 @@ Missiles.RegisterItem("FIM-92 SAM", "SAM", {
 		Model           = "models/missiles/fim_92.mdl",
 		RackModel       = "models/missiles/fim_92_folded.mdl",
 		MaxLength       = 152,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 60,
 		PropLength      = 80,
 		Thrust          = 200000, -- in kg*in/s^2
@@ -79,7 +79,7 @@ Missiles.RegisterItem("Strela-1 SAM", "SAM", {
 		RackModel       = "models/missiles/9m31f.mdl",
 		IgnoreRackModel = true, -- Ignore the rack model when determining the size of the round for ammo crates
 		MaxLength       = 180,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 60,
 		PropLength      = 100,
 		Thrust          = 800000, -- in kg*in/s^2

--- a/lua/acf/entities/missiles/uar.lua
+++ b/lua/acf/entities/missiles/uar.lua
@@ -48,7 +48,7 @@ Missiles.RegisterItem("RS82 ASR", "UAR", {
 	Round = {
 		Model           = "models/missiles/rs82.mdl",
 		MaxLength       = 60,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 25,
 		PropLength      = 35,
 		Thrust          = 50000, -- in kg*in/s^2
@@ -91,7 +91,7 @@ Missiles.RegisterItem("HVAR ASR", "UAR", {
 		Model           = "models/missiles/hvar.mdl",
 		RackModel       = "models/missiles/hvar_folded.mdl",
 		MaxLength       = 173,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 35.8,
 		PropLength      = 120,
 		Thrust          = 800000, -- in kg*in/s^2
@@ -135,7 +135,7 @@ Missiles.RegisterItem("SPG-9 ASR", "UAR", {
 		Model           = "models/missiles/rs82.mdl",
 		RackModel       = "models/missiles/rs82.mdl",
 		MaxLength       = 128.18,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 20.07,
 		PropLength      = 67.8,
 		Thrust          = 180000, -- in kg*in/s^2
@@ -179,7 +179,7 @@ Missiles.RegisterItem("S-24 ASR", "UAR", {
 	Round = {
 		Model           = "models/missiles/s24.mdl",
 		MaxLength       = 233,
-		Armor           = 2,
+		Armor           = 1,
 		ProjLength      = 103,
 		PropLength      = 130,
 		Thrust          = 2000000, -- in kg*in/s^2
@@ -220,7 +220,7 @@ Missiles.RegisterItem("RW61 ASR", "UAR", {
 		Model           = "models/missiles/RW61M.mdl",
 		RackModel       = "models/missiles/RW61M.mdl",
 		MaxLength       = 150,
-		Armor           = 5,
+		Armor           = 2,
 		ProjLength      = 60,
 		PropLength      = 90,
 		Thrust          = 700000, -- in kg*in/s^2

--- a/lua/entities/acf_gun/init.lua
+++ b/lua/entities/acf_gun/init.lua
@@ -902,9 +902,9 @@ do -- Metamethods --------------------------------
 			local AmmoType = AmmoTypes.Get(BulletData.Type)
 
 			if BulletData.CanFuze and SelfTbl.SetFuze then
-				local Variance = math.Rand(-0.015, 0.015) * math.max(0, 203 - SelfTbl.Caliber) * 0.01
+				local Variance = 0.00005 * math.Rand(-1, 1) * (math.max(0, 50 - SelfTbl.Caliber) + 30)
 
-				SelfTbl.Fuze = math.max(SelfTbl.SetFuze, 0.02) + Variance -- If possible, we're gonna update the fuze time
+				SelfTbl.Fuze = math.max(SelfTbl.SetFuze + Variance, 0.01) -- If possible, we update the fuze time
 			else
 				SelfTbl.Fuze = nil
 			end

--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -738,8 +738,8 @@ function ENT:ACF_OnDamage(DmgResult, DmgInfo)
 		local Ratio      = self.ACF.Health / self.ACF.MaxHealth
 		local BulletData = self.BulletData
 
-		-- The missile should detonate when it gets penetrated, but only have a chance to detonate if not penetrated.
-		if math.random() > 0.55 * Ratio or DmgResult.Penetration > self.ForcedArmor then
+		-- The missile should detonate when it gets penetrated.
+		if DmgResult.Penetration > self.ForcedArmor then
 			if BulletData.Type == "HEAT" then
 				BulletData.Type = "HE"
 

--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -449,6 +449,11 @@ function ACF.MakeMissile(Player, Pos, Ang, Rack, MountPoint, Crate)
 		Missile.SpeedBoost = Missile.StarterPercent * TotalLength * Missile.MaxThrust / (Missile.ProjMass + Missile.PropMass * 0.5)
 	end
 
+	if Missile.NoDamage then
+		Missile.ACF_InvisibleToBallistics = true
+		Missile.ACF_InvisibleToTrace = true
+	end
+
 	local PhysObj = Missile:GetPhysicsObject()
 
 	if IsValid(PhysObj) then
@@ -526,6 +531,9 @@ function ENT:Launch(Delay, IsMisfire)
 	self.ACF_Velocity = Velocity
 	self.LastVel      = Velocity
 	self.CurDir       = Flight
+
+	self.ACF_InvisibleToBallistics = false
+	self.ACF_InvisibleToTrace = false
 
 	if self.RackModel then
 		self:UpdateModel(self.RealModel)
@@ -716,6 +724,13 @@ function ENT:ACF_OnDamage(DmgResult, DmgInfo)
 
 	-- If the missile was destroyed, then we detonate it.
 	if HitRes.Kill then
+		local BulletData = self.BulletData
+
+		if BulletData.Type == "HEAT" then
+			BulletData.Type = "HE"
+
+			self:SetNW2String("AmmoType", "HE")
+		end
 		DetonateMissile(self, Owner)
 
 		return HitRes
@@ -723,36 +738,28 @@ function ENT:ACF_OnDamage(DmgResult, DmgInfo)
 		local Ratio      = self.ACF.Health / self.ACF.MaxHealth
 		local BulletData = self.BulletData
 
-		-- We give it a chance to explode when it gets penetrated aswell.
-		if math.random() > 0.55 * Ratio then
+		-- The missile should detonate when it gets penetrated, but only have a chance to detonate if not penetrated.
+		if math.random() > 0.55 * Ratio or DmgResult.Penetration > self.ForcedArmor then
 			if BulletData.Type == "HEAT" then
-			BulletData.Type = "HE"
+				BulletData.Type = "HE"
 
-			self:SetNW2String("AmmoType", "HE")
+				self:SetNW2String("AmmoType", "HE")
 			end
 			DetonateMissile(self, Owner)
 
 			return HitRes
 		end
 
-		-- Turning off the missile's motor.
+		-- Chance for any damage to disable the missile's motor.
 		if self.MotorLength > 0 and math.random() > 0.35 * Ratio then
 			self.MotorLength = 0
 
 			SetMotorState(self, false)
 		end
 
-		-- Turning off the missile's guidance.
+		-- Chance for any damage to disable the missile's guidance.
 		if self.UseGuidance and math.random() > 0.2 * Ratio then
 			self.UseGuidance = nil
-		end
-
-		-- Any Damage to the liner.
-		-- For sake of consistency and reducing of RNG on damage
-		if BulletData.Type == "HEAT" and 0.95 > Ratio then
-			BulletData.Type = "HE"
-
-			self:SetNW2String("AmmoType", "HE")
 		end
 	end
 


### PR DESCRIPTION
I'd like to propose a few changes mostly towards the balance of missiles, making interceptions a bit easier for everyone to attain, with the goal of improving the health of combat. This should satisfy any desire for APS entities, by using assets which are already provided by the addon. These changes were brought up as suggestions in the ACF Discord, where they weren't met with opposition.

1. Changes to the missile damage model
- Missiles now detonate if they are penetrated, whereas detonations previously relied entirely on dice rolls. This should make missile interceptions more deterministic
- Generally, missile armor values were lowered from 5mm to 2-3mm, and 2mm to 1mm. This makes HE more reliable at intercepting missiles by penetrating-to-kill
- Removed a simulated damage dice roll in the missile damage model where the shaped charge could be damaged, turning the warhead to HE. I can't see a case where the shaped charge could be damaged, where the warhead wouldn't be set off... could be re-added if desired?

2. Increase minimum fuzing caliber from 20mm to 25mm
- This should help to prevent people from strapping small, lightweight belt-fed guns with HE on a turret to intercept missiles, requiring them to invest a bit more to attain adequate protection. A further increase of the minimum fuzing caliber may be necessary, such as from 25mm to 30mm; the cost of missile interception mechanisms should fairly match their effectiveness
- Fixed some comments in the ammo files which stated the limit was exclusive, rather than inclusive

3. Refine fuze time calculation for bullets
- Airburst fuze noise for bullets is currently very bad for smaller calibers, especially with high velocity rounds. This change decreases the noise to a level which scales between the minimum fuzing caliber and 50mm, plus a base noise factor

4. Missile bug fixes
- Fixed a case where missiles would drop a HEAT / HE bullet rather than properly detonating
- Fixed pod-based missiles (which do not explode on their mounts, as the pod protects them) from being used as invincible armor

5. Decrease flechette minimum spread
- This change isn't related to missiles at all, though I felt that flechette was largely unused and could use some love. Decreased minimum spread from 1deg to 0.2deg