### PR TITLE
Rebalance damage, armor, and cost

### DIFF
--- a/lua/acf/core/globals.lua
+++ b/lua/acf/core/globals.lua
@@ -140,7 +140,7 @@ do -- ACF global vars
 
 	ACF.DefineSetting("ArmorCoef",            1,      "Armor coefficient has been set to %.2f.", ACF.FloatDataCallback(0.01, 2, 2))
 
-	ACF.DefineSetting("DamageCoef",           2,      "Damage coefficient has been set to %.2f.", ACF.FloatDataCallback(0.01, 2, 2))
+	ACF.DefineSetting("DamageCoef",           400,      "Damage coefficient has been set to %.2f.", ACF.FloatDataCallback(0.01, 1000, 2))
 
 	ACF.FuelRate = 15 -- Multiplier for fuel usage, 1.0 is approx real world
 	ACF.DefineSetting("FuelFactor",           1,      "Fuel rate multiplier has been set to a factor of %.2f.", ACF.FactorDataCallback("FuelRate", 0.01, 2, 2))
@@ -293,7 +293,7 @@ do -- ACF global vars
 		Copper		= 0.15,	-- Liner for HEAT cones
 		Tungsten	= 0.3,	-- Expensive
 		CompB		= 0.1,	-- Normal explosives
-		Octol		= 0.7,	-- Snowflakium, needs to be expensive as a balancing measure
+		Octol		= 0.4,	-- Snowflakium, needs to be expensive as a balancing measure
 
 		WP			= 0.01,	-- White phosphorus
 		SF			= 0.02,	-- Smoke filler

--- a/lua/acf/core/networking/model_data/volumetrics_sh.lua
+++ b/lua/acf/core/networking/model_data/volumetrics_sh.lua
@@ -128,7 +128,7 @@ do
         end
     end
 
-    local function ComputeVolumetricMesh(entity, isReInit)
+    local function ComputeVolumetricMesh(entity)
         if not IsValid(entity) then return end
         if not entity.IsACFEntity and not ArmorableClasses[entity:GetClass()] then return end
 

--- a/lua/acf/core/validation_sv.lua
+++ b/lua/acf/core/validation_sv.lua
@@ -226,5 +226,5 @@ function ACF.Activate(Entity)
 	EntTbl.ACF.MaxHealth = 1
 
 	ACF.UpdateArea(Entity, PhysObj)
-	ACF.ComputeVolumetricMesh(Entity, true)
+	ACF.ComputeVolumetricMesh(Entity)
 end

--- a/lua/acf/damage/damage_sv.lua
+++ b/lua/acf/damage/damage_sv.lua
@@ -292,15 +292,14 @@ function Damage.doPropDamage(Entity, DmgResult, DmgInfo)
 
 			for _, Hit in ipairs(ConvexHits) do
 				local Convex = MeshData.Convexes[Hit.ConvexID]
-				TotalLoss    = TotalLoss + (Hit.Volume / Convex.Volume) * Convex.MaxHealth * DamageCoef
+				TotalLoss    = TotalLoss + (Hit.Volume / Convex.Volume) * DamageCoef
 			end
 
 			EntACF.Health = math.max(0, EntACF.Health - TotalLoss)
 		else
 			for _, Hit in ipairs(ConvexHits) do
 				local Convex     = MeshData.Convexes[Hit.ConvexID]
-				local HealthLoss = (Hit.Volume / Convex.Volume) * Convex.MaxHealth * DamageCoef
-				-- print(Hit.Volume, Convex.Volume)
+				local HealthLoss = (Hit.Volume / Convex.Volume) * DamageCoef
 
 				Convex.Health = math.max(0, Convex.Health - HealthLoss)
 

--- a/lua/acf/damage/explosion_sv.lua
+++ b/lua/acf/damage/explosion_sv.lua
@@ -127,7 +127,7 @@ function Damage.createExplosion(Position, FillerMass, FragMass, Filter, DmgInfo)
 
 	local Power       = FillerMass * HEPower
 	local Radius      = Damage.getBlastRadius(FillerMass)
-	local RadiusScale = math.exp(max(Radius / Damage.getBlastRadius(1) - 1, 0))
+	local RadiusScale = math.exp((Radius / Damage.getBlastRadius(1) - 1) * 1.2)
 	local Found       = ents.FindInSphere(Position, Radius)
 
 	if EventViewer.Enabled() then

--- a/lua/acf/entities/armor_types/armor_types.lua
+++ b/lua/acf/entities/armor_types/armor_types.lua
@@ -17,7 +17,7 @@ local Types     = ACF.Classes.ArmorTypes
 local Armor = Types.Register("Default")
 function Armor:OnLoaded()
     self.Name        = "Default"
-    self.Description = "Does not set mass, used for default props."
+    self.Description = "Used as a default material for entities. Not intended to provide any protection."
     self.SuppressLoad = true
     self.Density     = 100
     self.CostMul     = 2.21
@@ -31,62 +31,62 @@ end
 local Armor = Types.Register("Flesh")
 function Armor:OnLoaded()
     self.Name        = "Flesh"
-    self.Description = "Soft tissue found in crew"
+    self.Description = "Soft tissue, used to represent crew members. Lab-grown for your convenience."
     self.Density     = 1100 -- https://www.sciencedirect.com/topics/immunology-and-microbiology/body-density
     self.CostMul     = 5
     self.HealthMul   = 33
     self.KineticMul  = 0.1
     self.ChemicalMul = 0.1
-    self.SpallMul    = 1.5
+    self.SpallMul    = 0.2
 end
 
 -- Diesel
 local Armor = Types.Register("Diesel")
 function Armor:OnLoaded()
     self.Name        = "Diesel"
-    self.Description = "Diesel fuel, provides no real protection and poses a fire risk when penetrated."
+    self.Description = "Diesel fuel, provides some protection against shaped charges. Doesn't explode, unlike petrol and Li-Ion batteries."
     self.SuppressLoad = true
     self.Density     = 745 -- lua/acf/entities/fuel_types/diesel.lua (0.745 kg/L)
     self.CostMul     = 2
-    self.HealthMul   = 3.725
-    self.KineticMul  = 0.02
-    self.ChemicalMul = 0.02
-    self.SpallMul    = 1.5
+    self.HealthMul   = 5
+    self.KineticMul  = 0.1
+    self.ChemicalMul = 0.2
+    self.SpallMul    = 0.1
 end
 
 -- Petrol
 local Armor = Types.Register("Petrol")
 function Armor:OnLoaded()
     self.Name        = "Petrol"
-    self.Description = "Petrol fuel, provides no real protection and is highly flammable when penetrated."
+    self.Description = "Petrol fuel, provides negligible protection. Prone to detonate when penetrated or damaged."
     self.SuppressLoad = true
     self.Density     = 832 -- lua/acf/entities/fuel_types/petrol.lua (0.832 kg/L)
-    self.CostMul     = 2.2
-    self.HealthMul   = 4.16
-    self.KineticMul  = 0.02
-    self.ChemicalMul = 0.02
-    self.SpallMul    = 2.0
+    self.CostMul     = 2.3
+    self.HealthMul   = 4
+    self.KineticMul  = 0.1
+    self.ChemicalMul = 0.1
+    self.SpallMul    = 0.1
 end
 
 -- Li-Ion
 local Armor = Types.Register("LiIon")
 function Armor:OnLoaded()
     self.Name        = "Li-Ion Battery"
-    self.Description = "Lithium-ion battery cells, fragile and prone to thermal runaway when penetrated."
+    self.Description = "Lithium-ion battery cells. Prone to detonate when penetrated or damaged."
     self.SuppressLoad = true
     self.Density     = 3890 -- lua/acf/entities/fuel_types/electric.lua (3.89 kg/L)
-    self.CostMul     = 50
-    self.HealthMul   = 77.8
-    self.KineticMul  = 0.1
-    self.ChemicalMul = 0.1
-    self.SpallMul    = 1.8
+    self.CostMul     = 8
+    self.HealthMul   = 2
+    self.KineticMul  = 0.3
+    self.ChemicalMul = 0.3
+    self.SpallMul    = 0.5
 end
 
 -- Aluminum
 local Armor = Types.Register("Aluminum")
 function Armor:OnLoaded()
     self.Name        = "Aluminum"
-    self.Description = "Lightweight but weak armor."
+    self.Description = "Decent protection for its price and density."
     self.Density     = 2700 -- https://en.wikipedia.org/wiki/Aluminium
     self.CostMul     = 17.9
     self.HealthMul   = 216
@@ -99,7 +99,7 @@ end
 local Armor = Types.Register("RHA")
 function Armor:OnLoaded()
     self.Name        = "RHA"
-    self.Description = "Rolled Homogeneous Armor, balanced protection."
+    self.Description = "Rolled Homogeneous Armor. The standard by which all other armor types are measured."
     self.Density     = 7840 -- https://metalzenith.com/blogs/steel-properties/rha-steel-properties-and-key-applications-in-defense
     self.CostMul     = 39.2 -- Reference: 0.005 points/kg
     self.HealthMul   = 784
@@ -112,63 +112,65 @@ end
 local Armor = Types.Register("GunSteel")
 function Armor:OnLoaded()
     self.Name        = "Gun Steel"
-    self.Description = "Steel used in gun construction, offers little protection on its own."
+    self.Description = "Material intended to represent guns. Much healthier than components, but worse in protection per unit volume for balance reasons."
+    self.SuppressLoad = true
     self.Density     = 7840 -- https://metalzenith.com/blogs/steel-properties/rha-steel-properties-and-key-applications-in-defense
     self.CostMul     = 39.2
-    self.HealthMul   = 784
-    self.KineticMul  = 0.1
-    self.ChemicalMul = 0.1
+    self.HealthMul   = 1568
+    self.KineticMul  = 0.7
+    self.ChemicalMul = 0.7
     self.SpallMul    = 1.0
 end
 
--- Component Steel
-local Armor = Types.Register("ComponentSteel")
+-- Component Material
+local Armor = Types.Register("Component")
 function Armor:OnLoaded()
-    self.Name        = "Component Steel"
-    self.Description = "Steel used in component housings, as fragile as aluminum."
+    self.Name        = "Component Material"
+    self.Description = "Material intended to represent components. Better protection than Gun Steel, but worse health for balance reasons."
+    self.SuppressLoad = true
     self.Density     = 2700 -- https://en.wikipedia.org/wiki/Aluminium
     self.CostMul     = 17.9
     self.HealthMul   = 54
     self.KineticMul  = 0.5
-    self.ChemicalMul = 0.6
-    self.SpallMul    = 0.5
+    self.ChemicalMul = 0.5
+    self.SpallMul    = 1
 end
 
 -- Rubber
 local Armor = Types.Register("Rubber")
 function Armor:OnLoaded()
     self.Name        = "Rubber"
-    self.Description = "Flexible but offers minimal protection."
+    self.Description = "Very cheap and light, but offers very little protection."
     self.Density     = 1500 -- * https://rubberandseal.com/what-is-the-density-of-rubber-sheets/
     self.CostMul     = 11.6
-    self.HealthMul   = 225
+    self.HealthMul   = 500
     self.KineticMul  = 0.2
-    self.ChemicalMul = 0.3
-    self.SpallMul    = 0.5
+    self.ChemicalMul = 0.4
+    self.SpallMul    = 0.1
 end
 
 -- Textolite
 local Armor = Types.Register("Textolite")
 function Armor:OnLoaded()
     self.Name        = "Textolite"
-    self.Description = "Composite material, good for lightweight applications."
+    self.Description = "Layered fibrous laminate material. Not much protection, but is cheap and light."
     self.Density     = 1800 -- * http://www.china-anza.com/2-1-7-textolite-3025.html
     self.CostMul     = 14.7
     self.HealthMul   = 180
     self.KineticMul  = 0.4
     self.ChemicalMul = 0.5
-    self.SpallMul    = 0.6
+    self.SpallMul    = 0.3
 end
 
 -- Tungsten
 local Armor = Types.Register("Tungsten")
 function Armor:OnLoaded()
     self.Name        = "Tungsten"
-    self.Description = "Very dense and strong, but heavy."
+    self.Description = "Extremely expensive and dense for equivalently good protection."
     self.Density     = 19250 -- https://en.wikipedia.org/wiki/Tungsten
     self.CostMul     = 72.2
     self.HealthMul   = 1347.5
-    self.KineticMul  = 1.5
+    self.KineticMul  = 1.4
     self.ChemicalMul = 1.2
     self.SpallMul    = 0.8
 end
@@ -177,26 +179,26 @@ end
 local Armor = Types.Register("DU")
 function Armor:OnLoaded()
     self.Name        = "Depleted Uranium"
-    self.Description = "Extremely dense with high protection."
+    self.Description = "Expensive and dense with high protection."
     self.Density     = 18700 -- https://pubmed.ncbi.nlm.nih.gov/11218253/
     self.CostMul     = 69.3
     self.HealthMul   = 1683
     self.KineticMul  = 1.3
     self.ChemicalMul = 1.1
-    self.SpallMul    = 1.0
+    self.SpallMul    = 1.3
 end
 
 -- Light ERA
 local Armor = Types.Register("LightERA")
 function Armor:OnLoaded()
     self.Name        = "Light ERA"
-    self.Description = "Explosive Reactive Armor, effective against shaped charges."
+    self.Description = "Explosive Reactive Armor. Effective primarily against shaped charges. Will explode when hit with enough energy."
     self.Density     = 5000 -- * https://below-the-turret-ring.blogspot.com/2016/04/explosive-reactive-armor-some-history.html
     self.CostMul     = 39.7
     self.HealthMul   = 250
     self.KineticMul  = 0.3
     self.ChemicalMul = 3.0
-    self.SpallMul    = 0.2
+    self.SpallMul    = 0.1
 
     self.IsExplosive        = true
     self.ExplosiveThreshold = 100 -- KJ; sensitive, will trigger off autocannon-grade rounds and up
@@ -207,13 +209,13 @@ end
 local Armor = Types.Register("HeavyERA")
 function Armor:OnLoaded()
     self.Name        = "Heavy ERA"
-    self.Description = "Heavy Explosive Reactive Armor, offers some protection against kinetic threats too."
+    self.Description = "Heavy Explosive Reactive Armor. Offers better protection against kinetic threats and takes more energy to detonate than Light ERA, but is twice as dense and more expensive."
     self.Density     = 10000 -- * https://below-the-turret-ring.blogspot.com/2016/04/explosive-reactive-armor-some-history.html
     self.CostMul     = 47.1
     self.HealthMul   = 600
     self.KineticMul  = 0.6
     self.ChemicalMul = 2.0
-    self.SpallMul    = 0.3
+    self.SpallMul    = 0.2
 
     self.IsExplosive        = true
     self.ExplosiveThreshold = 500 -- KJ; needs a heavier penetrator to set off

--- a/lua/acf/entities/guidance/active_radar.lua
+++ b/lua/acf/entities/guidance/active_radar.lua
@@ -6,7 +6,7 @@ if CLIENT then
 	Guidance.Description = "This guidance package uses a radar to detect contraptions and guides the munition towards the most centered one it can find."
 else
 	function Guidance:GetCost()
-		return 3
+		return 5
 	end
 
 	function Guidance:SeekTarget(Missile)

--- a/lua/acf/entities/guidance/antimissile.lua
+++ b/lua/acf/entities/guidance/antimissile.lua
@@ -8,7 +8,7 @@ else
 	Guidance.RadarType = "AM-Radar"
 
 	function Guidance:GetCost()
-		return 1
+		return 3
 	end
 
 	function Guidance:GetRadar()

--- a/lua/acf/entities/guidance/antiradiation.lua
+++ b/lua/acf/entities/guidance/antiradiation.lua
@@ -22,7 +22,7 @@ else
 	Guidance.MinDistance = 38750 -- Squared, ~5 meters
 
 	function Guidance:GetCost()
-		return 2
+		return 4
 	end
 
 	function Guidance:UpdateTarget(Missile)

--- a/lua/acf/entities/guidance/gps.lua
+++ b/lua/acf/entities/guidance/gps.lua
@@ -6,7 +6,7 @@ if CLIENT then
 	Guidance.Description = "This guidance package allows you to guide the munition to a desired point in the map."
 else
 	function Guidance:GetCost()
-		return 1
+		return 2
 	end
 
 	function Guidance:OnLaunched(Missile)

--- a/lua/acf/entities/guidance/infrared.lua
+++ b/lua/acf/entities/guidance/infrared.lua
@@ -6,7 +6,7 @@ if CLIENT then
 	Guidance.Description = "This guidance package will detect a contraption in front of itself and guide the munition towards it."
 else
 	function Guidance:GetCost()
-		return 2
+		return 3
 	end
 
 	function Guidance:UpdateTarget(Missile)

--- a/lua/acf/entities/guidance/laser.lua
+++ b/lua/acf/entities/guidance/laser.lua
@@ -21,7 +21,7 @@ else
 	local Lasers    = ACF.ActiveLasers
 
 	function Guidance:GetCost()
-		return 3
+		return 5
 	end
 
 	function Guidance.GetDirectionDot(Missile, TargetPos)

--- a/lua/acf/entities/guidance/radio_mclos.lua
+++ b/lua/acf/entities/guidance/radio_mclos.lua
@@ -12,7 +12,7 @@ else
 	local Trace     = ACF.trace
 
 	function Guidance:GetCost()
-		return 3
+		return 4
 	end
 
 	function Guidance:OnLaunched(Missile)

--- a/lua/acf/entities/guidance/radio_saclos.lua
+++ b/lua/acf/entities/guidance/radio_saclos.lua
@@ -7,7 +7,7 @@ else
 	local ZERO = Vector()
 
 	function Guidance:GetCost()
-		return 2
+		return 5
 	end
 
 	function Guidance:CheckComputer()

--- a/lua/acf/entities/guidance/semi_active_radar.lua
+++ b/lua/acf/entities/guidance/semi_active_radar.lua
@@ -7,7 +7,7 @@ else
 	Guidance.RadarType = "TGT-Radar"
 
 	function Guidance:GetCost()
-		return 2
+		return 5
 	end
 
 	-- Semi-actives can't seek targets by themselves

--- a/lua/acf/entities/guidance/wire_mclos.lua
+++ b/lua/acf/entities/guidance/wire_mclos.lua
@@ -21,7 +21,7 @@ else
 	Guidance.IsWire = true
 
 	function Guidance:GetCost()
-		return 3
+		return 4
 	end
 
 	function Guidance:OnLaunched(Missile)

--- a/lua/acf/entities/guidance/wire_saclos.lua
+++ b/lua/acf/entities/guidance/wire_saclos.lua
@@ -7,7 +7,7 @@ else
 	local ZERO = Vector()
 
 	function Guidance:GetCost()
-		return 3
+		return 5
 	end
 
 	function Guidance:CheckComputer()

--- a/lua/entities/acf_ammo/shared.lua
+++ b/lua/entities/acf_ammo/shared.lua
@@ -4,6 +4,6 @@ ENT.PrintName      = "ACF Ammo Crate"
 ENT.WireDebugName  = "ACF Ammo Crate"
 ENT.PluralName     = "ACF Ammo Crates"
 ENT.IsACFAmmoCrate = true
-ENT.ConvexMaterial = "ComponentSteel"
+ENT.ConvexMaterial = "Component"
 
 cleanup.Register("acf_ammo")

--- a/lua/entities/acf_autoloader/shared.lua
+++ b/lua/entities/acf_autoloader/shared.lua
@@ -7,7 +7,7 @@ ENT.ACF_Limit      = 2
 ENT.ACF_PreventArmoring = true
 
 ENT.IsACFAutoloader = true
-ENT.ConvexMaterial = "ComponentSteel"
+ENT.ConvexMaterial = "Component"
 
 -- Maps user var name to its type, whether it is client data and type specific arguments (all support defaults?)
 ENT.ACF_UserVars = {

--- a/lua/entities/acf_engine/shared.lua
+++ b/lua/entities/acf_engine/shared.lua
@@ -4,6 +4,6 @@ ENT.PrintName     = "ACF Engine"
 ENT.WireDebugName = "ACF Engine"
 ENT.PluralName    = "ACF Engines"
 ENT.IsACFEngine   = true
-ENT.ConvexMaterial = "ComponentSteel"
+ENT.ConvexMaterial = "Component"
 
 cleanup.Register("acf_engine")

--- a/lua/entities/acf_gearbox/shared.lua
+++ b/lua/entities/acf_gearbox/shared.lua
@@ -4,6 +4,6 @@ ENT.PrintName     = "ACF Gearbox"
 ENT.WireDebugName = "ACF Gearbox"
 ENT.PluralName    = "ACF Gearboxes"
 ENT.IsACFGearbox  = true
-ENT.ConvexMaterial = "ComponentSteel"
+ENT.ConvexMaterial = "Component"
 
 cleanup.Register("acf_gearbox")

--- a/lua/entities/acf_missile/shared.lua
+++ b/lua/entities/acf_missile/shared.lua
@@ -5,4 +5,4 @@ ENT.DoNotDuplicate    = true
 ENT.DisableDuplicator = true
 ENT.DoNotTrack        = true
 ENT.IsACFMissile         = true
-ENT.ConvexMaterial        = "ComponentSteel"
+ENT.ConvexMaterial        = "Component"

--- a/lua/entities/acf_rack/shared.lua
+++ b/lua/entities/acf_rack/shared.lua
@@ -6,6 +6,6 @@ ENT.WireDebugName = "ACF Rack"
 ENT.PluralName    = "ACF Racks"
 ENT.IsACFRack        = true
 ENT.IsACFWeapon      = true
-ENT.ConvexMaterial    = "ComponentSteel"
+ENT.ConvexMaterial    = "Component"
 
 cleanup.Register("acf_rack")

--- a/lua/entities/acf_radar/shared.lua
+++ b/lua/entities/acf_radar/shared.lua
@@ -5,6 +5,6 @@ ENT.Author        = "Bubbus"
 ENT.WireDebugName = "ACF Radar"
 ENT.PluralName    = "ACF Radars"
 ENT.IsACFRadar       = true
-ENT.ConvexMaterial = "ComponentSteel"
+ENT.ConvexMaterial = "Component"
 
 cleanup.Register("acf_radar")


### PR DESCRIPTION
Big balance changes to armor functionality, and some slight cost adjustments

- Damage was previously based on the max health of a convex, meaning that health didn't actually matter... All damage was proportional to the total health of each convex. Damage is now based on removed volume with a massively higher global multiplier to cope. Materials were additionally tuned to make more sense and offer niche fulfilling use cases to (hopefully) each material. Mileage may vary but seems fair from initial testing, needs actual combat to properly verify

- On top of the aforementioned damage rebalance, explosions were changed so that they have a damage curve; smaller explosions deal less damage, bigger ones deal more. Based on the radius which is tangentially correlated to blast energy, may need to be changed to be more accurate, but also seems good enough from initial testing

- Cost of some things was a bit off; for instance, GLATGM was ridiculously expensive compared to traditional missile options of similar performance. To try and remedy this with the available tuning variables, Octol filler was made quite a bit cheaper while the different guidance modes were made a bit more expensive to cope