### PR TITLE
Resolve nil cost

### DIFF
--- a/lua/acf/contraption/objects_sv/cost.lua
+++ b/lua/acf/contraption/objects_sv/cost.lua
@@ -65,10 +65,14 @@ do
 
 						C = op(ent)
 
-						ClassCost = ClassCost + C
-
 						local BulkCostAmt = Breakdown[BulkCostAmtID] or 0
-						Breakdown[BulkCostAmtID] = BulkCostAmt + C
+
+						if C == nil then
+							ACF.Utilities.Messages.PrintLog("Warning", "Nil cost for entity: " .. tostring(ent))
+						else
+							ClassCost = ClassCost + C
+							Breakdown[BulkCostAmtID] = BulkCostAmt + C
+						end
 					end
 				else
 					for ent in pairs(entlist) do
@@ -79,7 +83,11 @@ do
 
 						C = ent:GetCost()
 
-						ClassCost = ClassCost + C
+						if C == nil then
+							ACF.Utilities.Messages.PrintLog("Warning", "Nil cost for entity: " .. tostring(ent))
+						else
+							ClassCost = ClassCost + C
+						end
 					end
 				end
 			end

--- a/lua/acf/contraption/track_cost_sv.lua
+++ b/lua/acf/contraption/track_cost_sv.lua
@@ -229,7 +229,6 @@ do	-- Actual registration for known things
 
 		CostSystem.RegisterClassBulk("prop_physics", "armor")
 		CostSystem.RegisterClassBulk("primitive_shape", "armor")
-		CostSystem.RegisterClassBulk("gmod_wire_gate", "armor")
 		CostSystem.RegisterClassBulk("acf_baseplate", "armor")
 	end
 
@@ -322,10 +321,14 @@ do	-- Actual cost functions
 
 						C = op(ent)
 
-						ClassCost = ClassCost + C
-
 						local BulkCostAmt = Breakdown[BulkCostAmtID] or 0
-						Breakdown[BulkCostAmtID] = BulkCostAmt + C
+
+						if C == nil then
+							ACF.Utilities.Messages.PrintLog("Warning", "Nil cost for entity: " .. tostring(ent))
+						else
+							ClassCost = ClassCost + C
+							Breakdown[BulkCostAmtID] = BulkCostAmt + C
+						end
 					end
 				else
 					for ent in pairs(entlist) do
@@ -336,7 +339,11 @@ do	-- Actual cost functions
 
 						C = ent:GetCost()
 
-						ClassCost = ClassCost + C
+						if C == nil then
+							ACF.Utilities.Messages.PrintLog("Warning", "Nil cost for entity: " .. tostring(ent))
+						else
+							ClassCost = ClassCost + C
+						end
 					end
 				end
 


### PR DESCRIPTION
- Resolved wire gates being considered as a bulk armorable class, while they weren't whitelisted properly to be armorable in the first place. Gates can no longer be armored; just use props, primitives, or starfall props...

- Added warnings in case the cost for something is nil which we haven't found yet