### PR TITLE
Changed explosive damage scaling

### DIFF
--- a/lua/acf/contraption/track_cost_sv.lua
+++ b/lua/acf/contraption/track_cost_sv.lua
@@ -229,6 +229,10 @@ do	-- Actual registration for known things
 
 		CostSystem.RegisterClassBulk("prop_physics", "armor")
 		CostSystem.RegisterClassBulk("primitive_shape", "armor")
+		CostSystem.RegisterClassBulk("primitive_staircase", "armor")
+		CostSystem.RegisterClassBulk("primitive_ladder", "armor")
+		CostSystem.RegisterClassBulk("primitive_rail_slider", "armor")
+		CostSystem.RegisterClassBulk("primitive_airfoil", "armor")
 		CostSystem.RegisterClassBulk("acf_baseplate", "armor")
 	end
 

--- a/lua/acf/damage/explosion_sv.lua
+++ b/lua/acf/damage/explosion_sv.lua
@@ -127,7 +127,11 @@ function Damage.createExplosion(Position, FillerMass, FragMass, Filter, DmgInfo)
 
 	local Power       = FillerMass * HEPower
 	local Radius      = Damage.getBlastRadius(FillerMass)
-	local RadiusScale = math.exp((Radius / Damage.getBlastRadius(1) - 1) * 1.2)
+	local RadiusScale = math.exp((Radius / Damage.getBlastRadius(1) - 1) * 0.6)
+
+	-- Prevent runaway exponential scaling for huge explosions
+	RadiusScale = min(max(RadiusScale, 0.05), 5)
+
 	local Found       = ents.FindInSphere(Position, Radius)
 
 	if EventViewer.Enabled() then
@@ -298,7 +302,7 @@ function Damage.createExplosion(Position, FillerMass, FragMass, Filter, DmgInfo)
 		local Sphere        = max(4 * pi * (Distance * InchToCm) ^ 2, 1) -- Wavefront area at the target (cm²)
 		local EntArea       = HitEnt.ACF.Area
 		local SolidAngle    = min(EntArea / Sphere, 0.5)                 -- Fraction of the wavefront caught
-		local PowerFraction = Power * SolidAngle * RadiusScale            -- Blast energy intercepted (kJ)
+		local PowerFraction = Power * SolidAngle                         -- Blast energy intercepted (kJ)
 
 		-- Hopkinson-Cranz cube-root scaling: the lethal radius already scales as filler^(1/3), so the
 		-- scaled distance is simply Distance/Radius. The deposited blast impulse decays linearly across

--- a/lua/acf/entities/armor_types/armor_types.lua
+++ b/lua/acf/entities/armor_types/armor_types.lua
@@ -50,7 +50,7 @@ function Armor:OnLoaded()
     self.CostMul     = 2
     self.HealthMul   = 5
     self.KineticMul  = 0.1
-    self.ChemicalMul = 0.2
+    self.ChemicalMul = 0.3
     self.SpallMul    = 0.1
 end
 
@@ -142,10 +142,10 @@ function Armor:OnLoaded()
     self.Name        = "Rubber"
     self.Description = "Very cheap and light, but offers very little protection."
     self.Density     = 1500 -- * https://rubberandseal.com/what-is-the-density-of-rubber-sheets/
-    self.CostMul     = 11.6
-    self.HealthMul   = 500
-    self.KineticMul  = 0.2
-    self.ChemicalMul = 0.4
+    self.CostMul     = 12
+    self.HealthMul   = 350
+    self.KineticMul  = 0.15
+    self.ChemicalMul = 0.35
     self.SpallMul    = 0.1
 end
 


### PR DESCRIPTION
Did some further testing of HE against various targets after my previous tuning pass. I came to the conclusion that HE could deal massive amounts of damage to targets which were near the edge of the blast radius of an explosion. I tweaked the damage scaler I previously added, implemented a clamp so the bonus doesn't get too massive, and changed the way in which the scaler was applied so that targets further away from an explosion receive proportionately less damage. Seems significantly better than last state, combat testing would really help for more realistic testing data

The RadiusScale bonus isn't based on anything realistic, a different approach to explosive damage may be needed, but this "works"...