### PR TITLE
Missile damage rework, bug fix and HE FragHit calc adjustment

### DIFF
--- a/lua/acf/damage/explosion_sv.lua
+++ b/lua/acf/damage/explosion_sv.lua
@@ -316,7 +316,7 @@ function Damage.createExplosion(Position, FillerMass, FragMass, Filter, DmgInfo)
 		end
 
 		do -- Fragment damage
-			local FragHit = floor(Fragments * AreaFraction)
+			local FragHit = math.ceil(Fragments * AreaFraction)
 
 			if FragHit > 0 then
 				local Loss      = BaseFragV * Distance / Radius

--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -735,18 +735,53 @@ function ENT:ACF_OnDamage(DmgResult, DmgInfo)
 
 		return HitRes
 	elseif HitRes then
+		--If the missile is still on a rack it will be ignored
+		if not self.Launched then
+			return HitRes
+		end
+
 		local Ratio      = self.ACF.Health / self.ACF.MaxHealth
 		local BulletData = self.BulletData
 
-		-- The missile should detonate when it gets penetrated.
+		-- The missile will be considered destroyed when it gets penetrated.
 		if DmgResult.Penetration > self.ForcedArmor then
-			if BulletData.Type == "HEAT" then
-				BulletData.Type = "HE"
+			-- New death mechanic for ASM,AAM,ARM,SAM,ARTY,FFAR
+			if self.EntType == "Anti-Tank Guided Missiles" or self.EntType == "Air-To-Air Missiles" or self.EntType == "Anti-Radiation Missiles" or self.EntType == "Surface-To-Air Missiles" or self.EntType == "Artillery Rockets" or self.EntType == "Folding-Fin Aerial Rockets" then
+				BulletData.Type = "HP"
+				self:SetNW2String("AmmoType", "HP")
+				self.UseGuidance = nil
+				local MissileAngles = self.CurDir:Angle()
+				local LocalSpin  = VectorRand(-15, 15) / Ratio
+				self.RotAxis = MissileAngles:Up() * LocalSpin.z + MissileAngles:Right() * LocalSpin.y + MissileAngles:Forward() * LocalSpin.x
+				self.TorqueMul = 98
 
-				self:SetNW2String("AmmoType", "HE")
+				timer.Simple(Ratio,
+					function()
+						if not IsValid(self) then
+							return
+						end
+
+						self:SetNoDraw(true)
+						self:SetNotSolid(true)
+
+						local Effect = EffectData()
+						Effect:SetOrigin(self:GetPos())
+						Effect:SetRadius(BulletData.Caliber)
+						Effect:SetScale(BulletData.FillerMass or 1)
+						util.Effect("ACF_Explosion", Effect)
+
+						local GibModel	= "models/gibs/metal_gib%s.mdl"
+						self:SetNW2String("FlightModel", GibModel:format(math.random(1, 5)))
+						DetonateMissile(self, Owner)
+					end
+				)
+			else -- Old instant death mechanic for BOMB,GBOMB,GBU,UAR
+				if BulletData.Type == "HEAT" then
+					BulletData.Type = "HE"
+					self:SetNW2String("AmmoType", "HE")
+				end
+				DetonateMissile(self, Owner)
 			end
-			DetonateMissile(self, Owner)
-
 			return HitRes
 		end
 


### PR DESCRIPTION
- Changed HE FragHit calculation from floor to ceil. This ensures it rounds up to at least 1 hit instead of dropping to 0 due to flooring.

- Introduced a new delayed destruction mechanic for damaging specific guided/aerial missiles (Anti-Tank Guided Missiles, Air-To-Air Missiles, Anti-Radiation Missiles, Surface-To-Air Missiles, Artillery Rockets, and Folding-Fin Aerial Rockets).

Instead of instantly exploding upon taking damage, a random deviation is applied and a timer delays the final explosion based on the remaining health ratio. Explosion is harmless but will spawn a debris which is simulated by HP ammo type.
(Fully destroying the missile bypasses this mechanic)

- Free Falling Bombs, Gliding Bombs, Guided Bomb Units, Unguided Aerial Rockets does not use this mechanic and will instantly explode upon taking damage like before.

- Bug fix: Added a check to ensure missiles still attached to their rack dont instantly explode.