### PR TITLE
Missile damage rework, bug fix and HE FragHit calc adjustment

### DIFF
--- a/lua/acf/damage/explosion_sv.lua
+++ b/lua/acf/damage/explosion_sv.lua
@@ -316,7 +316,7 @@ function Damage.createExplosion(Position, FillerMass, FragMass, Filter, DmgInfo)
 		end
 
 		do -- Fragment damage
-			local FragHit = floor(Fragments * AreaFraction)
+			local FragHit = math.ceil(Fragments * AreaFraction)
 
 			if FragHit > 0 then
 				local Loss      = BaseFragV * Distance / Radius

--- a/lua/acf/entities/missiles/aam.lua
+++ b/lua/acf/entities/missiles/aam.lua
@@ -33,6 +33,7 @@ Missiles.RegisterItem("AIM-9 AAM", "AAM", {
 	ViewCone	= 30,
 	Agility		= 0.0017,
 	ArmDelay	= 0.2,
+	HitDeviate	= true,	
 	Round = {
 		Model           = "models/missiles/aim9m.mdl",
 		MaxLength       = 289,
@@ -76,6 +77,7 @@ Missiles.RegisterItem("AIM-120 AAM", "AAM", {
 	ViewCone	= 30,
 	Agility		= 0.006,
 	ArmDelay	= 0.2,
+	HitDeviate	= true,
 	Round = {
 		Model           = "models/missiles/aim120c.mdl",
 		MaxLength       = 370,
@@ -119,6 +121,7 @@ Missiles.RegisterItem("AIM-7 AAM", "AAM", {
 	ViewCone    = 20,
 	Agility     = 0.02,
 	ArmDelay    = 0.3,
+	HitDeviate	= true,
 	Round = {
 		Model           = "models/missiles/aim7f.mdl",
 		MaxLength       = 370,
@@ -162,6 +165,7 @@ Missiles.RegisterItem("AIM-54 AAM", "AAM", {
 	ViewCone	= 20,
 	Agility		= 0.02,
 	ArmDelay	= 0.4,
+	HitDeviate	= false,
 	Round = {
 		Model           = "models/missiles/aim54a.mdl",
 		MaxLength       = 400,

--- a/lua/acf/entities/missiles/aam.lua
+++ b/lua/acf/entities/missiles/aam.lua
@@ -33,7 +33,7 @@ Missiles.RegisterItem("AIM-9 AAM", "AAM", {
 	ViewCone	= 30,
 	Agility		= 0.0017,
 	ArmDelay	= 0.2,
-	HitDeviate	= true,	
+	HitDeviate	= true,
 	Round = {
 		Model           = "models/missiles/aim9m.mdl",
 		MaxLength       = 289,

--- a/lua/acf/entities/missiles/arm.lua
+++ b/lua/acf/entities/missiles/arm.lua
@@ -34,6 +34,7 @@ Missiles.RegisterItem("AGM-122 ASM", "ARM", {
 	ViewCone	= 20,
 	Agility		= 0.0018,
 	ArmDelay	= 0.2,
+	HitDeviate	= true,
 	Round = {
 		Model           = "models/missiles/aim9.mdl",
 		MaxLength       = 287,
@@ -76,6 +77,7 @@ Missiles.RegisterItem("AGM-45 ASM", "ARM", {
 	ViewCone	= 10,
 	Agility		= 0.012,
 	ArmDelay	= 0.3,
+	HitDeviate	= true,
 	Round = {
 		Model           = "models/missiles/aim120.mdl",
 		MaxLength       = 305,

--- a/lua/acf/entities/missiles/arty.lua
+++ b/lua/acf/entities/missiles/arty.lua
@@ -31,6 +31,7 @@ Missiles.RegisterItem("Type 63 RA", "ARTY", {
 	ViewCone	= 180,
 	Agility		= 0.08,
 	ArmDelay	= 0.2,
+	HitDeviate	= false,
 	Round = {
 		Model           = "models/missiles/glatgm/mgm51.mdl",
 		MaxLength       = 80,
@@ -73,6 +74,7 @@ Missiles.RegisterItem("SAKR-10 RA", "ARTY", {
 	Agility		= 0.001,
 	ViewCone	= 45,
 	ArmDelay	= 0.4,
+	HitDeviate	= true,
 	Round = {
 		Model           = "models/missiles/hvar_folded.mdl",
 		RackModel       = "models/missiles/hvar_folded.mdl",
@@ -116,6 +118,7 @@ Missiles.RegisterItem("SS-40 RA", "ARTY", {
 	Agility		= 0.004,
 	ViewCone	= 45,
 	ArmDelay	= 0.6,
+	HitDeviate	= false,
 	Round = {
 		Model           = "models/missiles/hvar_folded.mdl",
 		RackModel       = "models/missiles/hvar_folded.mdl",

--- a/lua/acf/entities/missiles/asm.lua
+++ b/lua/acf/entities/missiles/asm.lua
@@ -32,6 +32,7 @@ Missiles.RegisterItem("AT-3 ASM", "ATGM", {
 	SkinIndex	= { HEAT = 0, HE = 1 },
 	Agility		= 0.0005,
 	ArmDelay	= 0.1,
+	HitDeviate	= true,
 	Round = {
 		Model           = "models/missiles/at3.mdl",
 		MaxLength       = 86,
@@ -75,6 +76,7 @@ Missiles.RegisterItem("BGM-71E ASM", "ATGM", {
 	Fuzes		= { Contact = true },
 	Agility		= 0.00024,
 	ArmDelay	= 0.1,
+	HitDeviate	= true,
 	Round = {
 		Model           = "models/missiles/bgm_71e.mdl",
 		RackModel       = "models/missiles/bgm_71e_round.mdl",
@@ -121,6 +123,7 @@ Missiles.RegisterItem("AGM-114 ASM", "ATGM", {
 	SeekCone	= 10,
 	Agility		= 0.0008,
 	ArmDelay	= 0.5,
+	HitDeviate	= true,
 	Bodygroups = {
 		guidance = {
 			DataSource = function(Entity)
@@ -180,6 +183,7 @@ Missiles.RegisterItem("Ataka ASM", "ATGM", {
 	ViewCone	= 45,
 	Agility		= 0.00072,
 	ArmDelay	= 0.1,
+	HitDeviate	= true,
 	NoDamage    = true,
 	Round = {
 		Model           = "models/missiles/9m120.mdl",
@@ -226,6 +230,7 @@ Missiles.RegisterItem("9M133 ASM", "ATGM", {
 	ViewCone	= 20,
 	Agility		= 0.0004,
 	ArmDelay	= 0.1,
+	HitDeviate	= true,
 	Bodygroups = {
 		fins = {
 			DataSource = function()
@@ -286,6 +291,7 @@ Missiles.RegisterItem("AT-2 ASM", "ATGM", {
 	ViewCone	= 90,
 	Agility		= 0.00035,
 	ArmDelay	= 0.1,
+	HitDeviate	= true,
 	Round = {
 		Model           = "models/missiles/at2.mdl",
 		MaxLength       = 116,

--- a/lua/acf/entities/missiles/bomb.lua
+++ b/lua/acf/entities/missiles/bomb.lua
@@ -31,6 +31,7 @@ Missiles.RegisterItem("50kgBOMB", "BOMB", {
 	Fuzes		= { Contact = true, Optical = true},
 	Agility		= 1,
 	ArmDelay	= 0.5,
+	HitDeviate	= false,
 	Round = {
 		Model           = "models/bombs/fab50.mdl",
 		MaxLength       = 109,
@@ -72,6 +73,7 @@ Missiles.RegisterItem("100kgBOMB", "BOMB", {
 	Fuzes		= { Contact = true, Optical = true},
 	Agility		= 1,
 	ArmDelay	= 1,
+	HitDeviate	= false,
 	Round = {
 		Model           = "models/bombs/fab100.mdl",
 		MaxLength       = 106,
@@ -113,6 +115,7 @@ Missiles.RegisterItem("250kgBOMB", "BOMB", {
 	Fuzes		= { Contact = true, Optical = true},
 	Agility		= 1,
 	ArmDelay	= 1,
+	HitDeviate	= false,
 	Round = {
 		Model           = "models/bombs/fab250.mdl",
 		MaxLength       = 145,
@@ -154,6 +157,7 @@ Missiles.RegisterItem("500kgBOMB", "BOMB", {
 	Fuzes		= { Contact = true, Optical = true},
 	Agility		= 1,
 	ArmDelay	= 2,
+	HitDeviate	= false,
 	Round = {
 		Model           = "models/bombs/fab500.mdl",
 		MaxLength       = 240,
@@ -195,6 +199,7 @@ Missiles.RegisterItem("1000kgBOMB", "BOMB", {
 	Fuzes		= { Contact = true, Optical = true},
 	Agility		= 1,
 	ArmDelay	= 3,
+	HitDeviate	= false,
 	Round = {
 		Model           = "models/bombs/an_m66.mdl",
 		MaxLength       = 270,

--- a/lua/acf/entities/missiles/ffar.lua
+++ b/lua/acf/entities/missiles/ffar.lua
@@ -30,6 +30,7 @@ Missiles.RegisterItem("40mmFFAR", "FFAR", {
 	Fuzes		= { Contact = true, Timed = true },
 	Agility     = 1,
 	ArmDelay	= 0.1,
+	HitDeviate	= true,
 	Round = {
 		Model           = "models/missiles/ffar_40mm.mdl",
 		RackModel       = "models/missiles/ffar_40mm_closed.mdl",
@@ -71,6 +72,7 @@ Missiles.RegisterItem("57mmFFAR", "FFAR", {
 	Fuzes		= { Contact = true, Timed = true },
 	Agility		= 1,
 	ArmDelay	= 0.1,
+	HitDeviate	= true,
 	Round = {
 		Model           = "models/missiles/ffar_70mm.mdl",
 		RackModel       = "models/missiles/ffar_70mm_closed.mdl",
@@ -112,6 +114,7 @@ Missiles.RegisterItem("70mmFFAR", "FFAR", {
 	Fuzes		= { Contact = true, Timed = true },
 	Agility		= 0.05,
 	ArmDelay	= 0.1,
+	HitDeviate	= true,
 	Round = {
 		Model           = "models/missiles/ffar_70mm.mdl",
 		RackModel       = "models/missiles/ffar_70mm_closed.mdl",
@@ -153,6 +156,7 @@ Missiles.RegisterItem("80mmFFAR", "FFAR", {
 	Fuzes		= { Contact = true, Timed = true },
 	Agility		= 0.05,
 	ArmDelay	= 0.1,
+	HitDeviate	= true,
 	Round = {
 		Model           = "models/missiles/ffar_70mm.mdl",
 		RackModel       = "models/missiles/ffar_70mm_closed.mdl",
@@ -194,6 +198,7 @@ Missiles.RegisterItem("Zuni ASR", "FFAR", {
 	Fuzes		= { Contact = true, Timed = true, Optical = true, Radio = true, Altitude = true },
 	Agility		= 0.05,
 	ArmDelay	= 0.1,
+	HitDeviate	= true,
 	Round = {
 		Model           = "models/ghosteh/zuni.mdl",
 		RackModel       = "models/ghosteh/zuni_folded.mdl",

--- a/lua/acf/entities/missiles/gbomb.lua
+++ b/lua/acf/entities/missiles/gbomb.lua
@@ -29,6 +29,7 @@ Missiles.RegisterItem("100kgGBOMB", "GBOMB", {
 	Navigation  = "Chase",
 	Fuzes		= { Contact = true, Optical = true},
 	ArmDelay	= 1,
+	HitDeviate	= false,
 	Round = {
 		Model           = "models/missiles/micro.mdl",
 		MaxLength       = 100,
@@ -68,6 +69,7 @@ Missiles.RegisterItem("250kgGBOMB", "GBOMB", {
 	Navigation  = "Chase",
 	Fuzes		= { Contact = true, Optical = true},
 	ArmDelay	= 1,
+	HitDeviate	= false,
 	Round = {
 		Model           = "models/missiles/fab250.mdl",
 		MaxLength       = 150,

--- a/lua/acf/entities/missiles/gbu.lua
+++ b/lua/acf/entities/missiles/gbu.lua
@@ -32,6 +32,7 @@ Missiles.RegisterItem("WalleyeGBU", "GBU", {
 	ViewCone	= 120,
 	Agility		= 0.04,
 	ArmDelay	= 1,
+	HitDeviate	= false,
 	Round = {
 		Model           = "models/bombs/gbu/agm62.mdl",
 		MaxLength       = 345,
@@ -75,6 +76,7 @@ Missiles.RegisterItem("227kgGBU", "GBU", {
 	ViewCone	= 80,
 	Agility		= 0.015,
 	ArmDelay	= 1,
+	HitDeviate	= false,
 	Bodygroups = {
 		guidance = {
 			DataSource = function(Entity)
@@ -134,6 +136,7 @@ Missiles.RegisterItem("454kgGBU", "GBU", {
 	ViewCone	= 80,
 	Agility		= 0.03,
 	ArmDelay	= 1,
+	HitDeviate	= false,
 	Bodygroups = {
 		guidance = {
 			DataSource = function(Entity)
@@ -193,6 +196,7 @@ Missiles.RegisterItem("909kgGBU", "GBU", {
 	ViewCone	= 80,
 	Agility		= 0.05,
 	ArmDelay	= 3,
+	HitDeviate	= false,
 	Bodygroups = {
 		guidance = {
 			DataSource = function(Entity)

--- a/lua/acf/entities/missiles/sam.lua
+++ b/lua/acf/entities/missiles/sam.lua
@@ -32,6 +32,7 @@ Missiles.RegisterItem("FIM-92 SAM", "SAM", {
 	ViewCone	= 30,
 	Agility		= 0.0002,
 	ArmDelay	= 0.2,
+	HitDeviate	= true,
 	Round = {
 		Model           = "models/missiles/fim_92.mdl",
 		RackModel       = "models/missiles/fim_92_folded.mdl",
@@ -74,6 +75,7 @@ Missiles.RegisterItem("Strela-1 SAM", "SAM", {
 	ViewCone	= 40,
 	Agility		= 0.0006,
 	ArmDelay	= 0.2,
+	HitDeviate	= true,
 	Round = {
 		Model           = "models/missiles/9m31.mdl",
 		RackModel       = "models/missiles/9m31f.mdl",

--- a/lua/acf/entities/missiles/uar.lua
+++ b/lua/acf/entities/missiles/uar.lua
@@ -32,6 +32,7 @@ Missiles.RegisterItem("RS82 ASR", "UAR", {
 	Fuzes		= { Contact = true, Timed = true },
 	Agility     = 1,
 	ArmDelay	= 0.3,
+	HitDeviate	= true,
 	Bodygroups = {
 		warhead = {
 			DataSource = function(Entity)
@@ -87,6 +88,7 @@ Missiles.RegisterItem("HVAR ASR", "UAR", {
 	Fuzes		= { Contact = true, Timed = true },
 	Agility     = 1,
 	ArmDelay	= 0.3,
+	HitDeviate	= true,
 	Round = {
 		Model           = "models/missiles/hvar.mdl",
 		RackModel       = "models/missiles/hvar_folded.mdl",
@@ -131,6 +133,7 @@ Missiles.RegisterItem("SPG-9 ASR", "UAR", {
 	Fuzes		= { Contact = true },
 	Agility     = 1,
 	ArmDelay	= 0, -- :)
+	HitDeviate	= false,
 	Round = {
 		Model           = "models/missiles/rs82.mdl",
 		RackModel       = "models/missiles/rs82.mdl",
@@ -176,6 +179,7 @@ Missiles.RegisterItem("S-24 ASR", "UAR", {
 	SkinIndex	= { HEAT = 0, HE = 1 },
 	Agility     = 1,
 	ArmDelay	= 0.3,
+	HitDeviate	= false,
 	Round = {
 		Model           = "models/missiles/s24.mdl",
 		MaxLength       = 233,
@@ -216,6 +220,7 @@ Missiles.RegisterItem("RW61 ASR", "UAR", {
 	Fuzes		= { Contact = true, Optical = true },
 	Agility		= 1,
 	ArmDelay	= 0.2,
+	HitDeviate	= false,
 	Round = {
 		Model           = "models/missiles/RW61M.mdl",
 		RackModel       = "models/missiles/RW61M.mdl",

--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -747,7 +747,7 @@ function ENT:ACF_OnDamage(DmgResult, DmgInfo)
 		-- The missile will be considered destroyed when it gets penetrated.
 		if DmgResult.Penetration > self.ForcedArmor then
 			-- New death mechanic for ASM,AAM,ARM,SAM,ARTY,FFAR
-			if Missile.HitDeviate then
+			if self.HitDeviate then
 				BulletData.Type = "HP"
 				self:SetNW2String("AmmoType", "HP")
 				self.UseGuidance = nil

--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -735,18 +735,53 @@ function ENT:ACF_OnDamage(DmgResult, DmgInfo)
 
 		return HitRes
 	elseif HitRes then
+		--If the missile is still on a rack it will be ignored
+		if not self.Launched then
+			return HitRes
+		end
+
 		local Ratio      = self.ACF.Health / self.ACF.MaxHealth
 		local BulletData = self.BulletData
 
-		-- The missile should detonate when it gets penetrated.
+		-- The missile will be considered destroyed when it gets penetrated.
 		if DmgResult.Penetration > self.ForcedArmor then
-			if BulletData.Type == "HEAT" then
-				BulletData.Type = "HE"
+			-- New death mechanic for ASM,AAM,ARM,SAM,ARTY,FFAR
+			if self.EntType == "Anti-Tank Guided Missiles" or self.EntType == "Air-To-Air Missiles" or self.EntType == "Anti-Radiation Missiles" or self.EntType == "Surface-To-Air Missiles" or self.EntType == "Artillery Rockets" or self.EntType == "Folding-Fin Aerial Rockets" then
+				BulletData.Type = "HP"
+				self:SetNW2String("AmmoType", "HP")
+				self.UseGuidance = nil
+				local MissileAngles = self.CurDir:Angle()
+				local LocalSpin  = VectorRand(-15, 15) / Ratio
+				self.RotAxis = MissileAngles:Up() * LocalSpin.z + MissileAngles:Right() * LocalSpin.y + MissileAngles:Forward() * LocalSpin.x
+				self.TorqueMul = 98
 
-				self:SetNW2String("AmmoType", "HE")
+				timer.Simple(Ratio,
+					function()
+						if not IsValid(self) then
+							return
+						end
+
+						self:SetNoDraw(true)
+						self:SetNotSolid(true)
+
+						local Effect = EffectData()
+						Effect:SetOrigin(self:GetPos())
+						Effect:SetRadius(BulletData.Caliber)
+						Effect:SetScale(BulletData.FillerMass or 1)
+						util.Effect("ACF_Explosion", Effect)
+
+						local GibModel	= "models/gibs/metal_gib%s.mdl"
+						self:SetNW2String("FlightModel", GibModel:format(math.random(1, 5)))
+						DetonateMissile(self, Owner)
+					end
+				)
+			else -- Old instant death mechanic for BOMB,GBOMB,GBU,UAR
+				if BulletData.Type == "HEAT" then
+					BulletData.Type = "HE"
+					self:SetNW2String("AmmoType", "HE")
+				end
+				DetonateMissile(self, Owner)
 			end
-			DetonateMissile(self, Owner)
-
 			return HitRes
 		end
 

--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -396,6 +396,7 @@ function ACF.MakeMissile(Player, Pos, Ang, Rack, MountPoint, Crate)
 	Missile.ForcedArmor     = Round.Armor
 	Missile.Effect          = Data.Effect or Class.Effect
 	Missile.NoDamage        = Rack.ProtectMissile or Data.NoDamage
+	Missile.HitDeviate      = Data.HitDeviate
 	Missile.ExhaustPos      = Data.ExhaustPos or Vector()
 	Missile.Bodygroups      = Data.Bodygroups
 	Missile.RackModel       = Rack.MissileModel or Round.RackModel
@@ -746,7 +747,7 @@ function ENT:ACF_OnDamage(DmgResult, DmgInfo)
 		-- The missile will be considered destroyed when it gets penetrated.
 		if DmgResult.Penetration > self.ForcedArmor then
 			-- New death mechanic for ASM,AAM,ARM,SAM,ARTY,FFAR
-			if self.EntType == "Anti-Tank Guided Missiles" or self.EntType == "Air-To-Air Missiles" or self.EntType == "Anti-Radiation Missiles" or self.EntType == "Surface-To-Air Missiles" or self.EntType == "Artillery Rockets" or self.EntType == "Folding-Fin Aerial Rockets" then
+			if Missile.HitDeviate then
 				BulletData.Type = "HP"
 				self:SetNW2String("AmmoType", "HP")
 				self.UseGuidance = nil


### PR DESCRIPTION
Changed HE FragHit calculation from floor to ceil. This ensures it rounds up to at least 1 hit instead of dropping to 0 due to flooring.

Introduced a new delayed destruction mechanic for damaging specific guided/aerial missiles (Anti-Tank Guided Missiles, Air-To-Air Missiles, Anti-Radiation Missiles, Surface-To-Air Missiles, Artillery Rockets, and Folding-Fin Aerial Rockets).

- Instead of instantly exploding upon taking damage, a random deviation is applied and a timer delays the final explosion based on the remaining health ratio. Explosion is harmless but will spawn a debris which is simulated by HP ammo type.
(Fully destroying the missile bypasses this mechanic)

Free Falling Bombs, Gliding Bombs, Guided Bomb Units, Unguided Aerial Rockets does not use this mechanic and will instantly explode upon taking damage like before.

Bug fix: Added a check to ensure missiles still attached to their rack dont instantly explode.