### PR TITLE
Crew rework

### DIFF
--- a/lua/acf/core/classes/turrets/registration.lua
+++ b/lua/acf/core/classes/turrets/registration.lua
@@ -19,7 +19,12 @@ function Turrets.Register(ID, Data)
 end
 
 function Turrets.RegisterItem(ID, ClassID, Data)
-	return Classes.AddGroupItem(ID, ClassID, Entries, Data)
+	local Item = Classes.AddGroupItem(ID, ClassID, Entries, Data)
+
+	-- Lets an item have its own spawn limit independent of the group, same as CrewTypes.Register
+	if Item.LimitConVar then Classes.AddSboxLimit(Item.LimitConVar) end
+
+	return Item
 end
 
 Classes.AddGroupedFunctions(Turrets, Entries)

--- a/lua/acf/core/globals.lua
+++ b/lua/acf/core/globals.lua
@@ -385,6 +385,10 @@ do -- ACF global vars
 	ACF.DriverEfficiencyThreshold = 0.3	-- Minimum TotalEff a Driver/Pilot needs to grant full gearbox torque
 	ACF.GunnerEfficiencyThreshold = 0.3	-- Minimum TotalEff a Gunner/Commander/Pilot needs to render a turret controlled
 	ACF.UncontrolledAimUpdateInterval = 5	-- Seconds between aim input updates on an uncontrolled weaponized turret
+	ACF.WeaponClasses = { -- Entity classes that make a turret weaponized if directly parented to it
+		acf_gun		= true,
+		acf_rack	= true
+	}
 
 	ACF.CrewRepTimeBase 	= 3		-- Base time to replace a crew member
 	ACF.CrewRepDistToTime 	= 0.05 	-- Time it takes for crew to move one inch during replacement

--- a/lua/acf/core/globals.lua
+++ b/lua/acf/core/globals.lua
@@ -370,6 +370,7 @@ do -- ACF global vars
 	ACF.ContainerMinSize   = 6 -- Defines the shortest possible length of containers (fuel tanks, supply crates) for all their axises, in gmu
 	ACF.ContainerMaxSize   = 96 -- Defines the highest possible length of containers (fuel tanks, supply crates) for all their axises, in gmu
 	ACF.FuelSupplyColor    = Color(76, 201, 250, 10) -- The color to use for the fuel supply effect
+	ACF.CrewSupplyColor    = Color(255, 80, 200, 10) -- The color to use for the crew revival supply effect
 	ACF.LiIonED            = 0.458 -- li-ion energy density: kw hours / liter
 	ACF.SupplyDistance     = 300 -- Distance in which supply units distribute mass to containers.
 	ACF.SupplyMassRate     = 0.007017 -- kg per second per cubic inch of supply unit volume (no distance attenuation)
@@ -391,7 +392,6 @@ do -- ACF global vars
 	ACF.CrewRepPrioMax 		= 10	-- Maximum priority for crew replacement
 
 	ACF.CrewRegenFraction	= 0.05	-- Fraction of max health a living, non-full-health crew member regenerates roughly every 10 seconds
-	ACF.CrewSupplyColor	= Color(255, 80, 200, 10) -- The color to use for the crew revival supply effect
 
 	ACF.CrewSpaceLengthMod 	= 0.425	-- Changes contribution of shell length to ideal crew space
 	ACF.CrewSpaceCaliberMod = 1.0	-- Changes contribution of shell caliber to ideal crew space

--- a/lua/acf/core/globals.lua
+++ b/lua/acf/core/globals.lua
@@ -389,6 +389,7 @@ do -- ACF global vars
 		acf_gun		= true,
 		acf_rack	= true
 	}
+	ACF.LightweightTurretMassLimit = 250	-- kg. Turrets at or under this carried mass can be controlled by a shared-parent Gunner, or a Lightweight Turret Controller, without needing to be mounted on it
 
 	ACF.CrewRepTimeBase 	= 3		-- Base time to replace a crew member
 	ACF.CrewRepDistToTime 	= 0.05 	-- Time it takes for crew to move one inch during replacement

--- a/lua/acf/core/globals.lua
+++ b/lua/acf/core/globals.lua
@@ -114,6 +114,7 @@ end
 do -- ACF global vars
 	ACF.AmmoCrates           = ACF.AmmoCrates or {}
 	ACF.FuelTanks            = ACF.FuelTanks or {}
+	ACF.ActiveCrews          = ACF.ActiveCrews or {}
 	ACF.Repositories         = ACF.Repositories or {}
 	ACF.ClientData           = ACF.ClientData or {}
 	ACF.ServerData           = ACF.ServerData or {}
@@ -380,10 +381,17 @@ do -- ACF global vars
 	ACF.CrewCommanderCoef 	= 0.3	-- Portion of a crew's efficiency the commander provides
 	ACF.CrewSelfCoef 		= 1.0	-- Portion of a crew's efficiency they provide
 
+	ACF.DriverEfficiencyThreshold = 0.3	-- Minimum TotalEff a Driver/Pilot needs to grant full gearbox torque
+	ACF.GunnerEfficiencyThreshold = 0.3	-- Minimum TotalEff a Gunner/Commander/Pilot needs to render a turret controlled
+	ACF.UncontrolledAimUpdateInterval = 5	-- Seconds between aim input updates on an uncontrolled weaponized turret
+
 	ACF.CrewRepTimeBase 	= 3		-- Base time to replace a crew member
 	ACF.CrewRepDistToTime 	= 0.05 	-- Time it takes for crew to move one inch during replacement
 	ACF.CrewRepPrioMin 		= 1		-- Minimum priority for crew replacement
 	ACF.CrewRepPrioMax 		= 10	-- Maximum priority for crew replacement
+
+	ACF.CrewRegenFraction	= 0.05	-- Fraction of max health a living, non-full-health crew member regenerates roughly every 10 seconds
+	ACF.CrewSupplyColor	= Color(255, 80, 200, 10) -- The color to use for the crew revival supply effect
 
 	ACF.CrewSpaceLengthMod 	= 0.425	-- Changes contribution of shell length to ideal crew space
 	ACF.CrewSpaceCaliberMod = 1.0	-- Changes contribution of shell caliber to ideal crew space

--- a/lua/acf/core/utilities/effects/effects_cl.lua
+++ b/lua/acf/core/utilities/effects/effects_cl.lua
@@ -58,14 +58,14 @@ do -- Resupply effect
 		end
 	end
 
-	local function Add(Entity, RefilledAmmo, RefilledFuel)
+	local function Add(Entity, RefilledAmmo, RefilledFuel, RevivedCrew)
 		if not IsValid(Entity) then return end
 
 		if not next(Supplies) then
 			hook.Add("PostDrawOpaqueRenderables", "ACF_Supply", DrawSpheres)
 		end
 
-		Supplies[Entity] = { Ammo = RefilledAmmo, Fuel = RefilledFuel }
+		Supplies[Entity] = { Ammo = RefilledAmmo, Fuel = RefilledFuel, Crew = RevivedCrew }
 
 		Entity:CallOnRemove("ACF_Supply", Remove)
 	end
@@ -74,8 +74,9 @@ do -- Resupply effect
 		local Entity = net.ReadEntity()
 		local RefilledAmmo = net.ReadBool()
 		local RefilledFuel = net.ReadBool()
+		local RevivedCrew = net.ReadBool()
 
-		Add(Entity, RefilledAmmo, RefilledFuel)
+		Add(Entity, RefilledAmmo, RefilledFuel, RevivedCrew)
 	end)
 
 	net.Receive("ACF_StopSupplyEffect", function()

--- a/lua/acf/core/utilities/util_cl.lua
+++ b/lua/acf/core/utilities/util_cl.lua
@@ -646,14 +646,14 @@ do -- Default turret menus
 			MaxDeg:SetValue(180)
 
 			if Data.ID == "Turret-V" then
-				MinDeg:SetMin(-85)
-				MaxDeg:SetMax(85)
+				MinDeg:SetMin(-90)
+				MaxDeg:SetMax(90)
 
-				MinDeg:SetValue(-85)
-				MaxDeg:SetValue(85)
+				MinDeg:SetValue(-90)
+				MaxDeg:SetValue(90)
 
-				ACF.SetClientData("MinDeg", -85)
-				ACF.SetClientData("MaxDeg", 85)
+				ACF.SetClientData("MinDeg", -90)
+				ACF.SetClientData("MaxDeg", 90)
 			else
 				ACF.SetClientData("MinDeg", -180)
 				ACF.SetClientData("MaxDeg", 180)
@@ -1009,6 +1009,22 @@ do -- Default turret menus
 			if Data.IsDual then
 				Menu:AddLabel("#acf.menu.gyros.dual_desc")
 			end
+
+			if Menu.ComponentPreview then
+				Menu.ComponentPreview:SetModelScale(1, true)
+			end
+		end
+	end
+
+	do	-- Turret Controllers
+		function ACF.CreateTurretControllerMenu(Data, Menu)
+			ACF.SetClientData("Controller", Data.ID)
+			ACF.SetClientData("Destiny", "TurretControllers")
+			ACF.SetClientData("PrimaryClass", "acf_turret_controller")
+			ACF.SetClientData("SecondaryClass", "N/A")
+
+			local MassText = language.GetPhrase("acf.menu.turrets.mass_text")
+			Menu:AddLabel(MassText:format(Data.Mass))
 
 			if Menu.ComponentPreview then
 				Menu.ComponentPreview:SetModelScale(1, true)

--- a/lua/acf/core/utilities/util_sh.lua
+++ b/lua/acf/core/utilities/util_sh.lua
@@ -1268,9 +1268,9 @@ end
 
 do
 	local VECTOR = FindMetaTable("Vector")
-	--- Sets up a table to track G forces. The vectors inside are mutable!! Be careful of that!!!!
+	--- Sets up a table to track G-forces. The vectors inside are mutable!! Be careful of that!!!!
 	--- (this is for performance reasons so we don't make thousands vectors per second potentially)
-	--- Use with ACF.UpdateGForceTracker to update the G force tracker.
+	--- Use with ACF.UpdateGForceTracker to update the G-force tracker.
 	--- @param pos? Vector The initial position
 	--- @param vel? Vector The initial velocity
 	--- @param accel? Vector The initial acceleration
@@ -1303,10 +1303,10 @@ do
 
 	local DeltaTime = engine.TickInterval()
 
-	--- Returns the G force given the current position and the time since the last update.
-	--- @param tbl table The table storing the G force tracker data
+	--- Returns the G-force given the current position and the time since the last update.
+	--- @param tbl table The table storing the G-force tracker data
 	--- @param newPos Vector The new position to update the tracker with
-	--- @return number, number The G force experienced and the delta time since the last update
+	--- @return number, number The G-force experienced and the delta time since the last update
 	function ACF.UpdateGForceTracker(tbl, newPos, sampleRate)
 		if not tbl then return end
 

--- a/lua/acf/core/utilities/util_sv.lua
+++ b/lua/acf/core/utilities/util_sv.lua
@@ -1,6 +1,19 @@
 local ACF = ACF
 local Notify = ACF.Utilities.Notify
 
+do -- Combat state
+	local CombatTimeout = 30 / engine.TickInterval() -- 30 seconds
+
+	--- Whether an entity's contraption has fired a weapon or taken prop damage recently.
+	--- Shared by anything that should pause while a vehicle is actively fighting (crew health
+	--- regen, supply crate resupplying).
+	--- @param Entity table Any entity belonging to the contraption to check
+	function ACF.IsContraptionInCombat(Entity)
+		local Contraption = Entity:CFW_GetContraption()
+		return Contraption and Contraption.InCombat and (engine.TickCount() - Contraption.InCombat) < CombatTimeout
+	end
+end
+
 -- 16 Segments font created by ThorType
 -- Huge thanks to LiddulBOFH to help me get it working
 -- Source: https://www.dafont.com/16-segments.font

--- a/lua/acf/entities/crew_types/crew_types.lua
+++ b/lua/acf/entities/crew_types/crew_types.lua
@@ -125,7 +125,7 @@ CrewTypes.Register("Gunner", {
 	},
 	GForceInfo = {
 		Efficiencies = {
-			Min = 1.5,	-- Best efficiency before this (Gs)
+			Min = 1,	-- Best efficiency before this (Gs)
 			Max = 4,	-- Worst efficiency after this (Gs)
 		},
 		Damages = {
@@ -171,7 +171,7 @@ CrewTypes.Register("Driver", {
 	},
 	GForceInfo = {
 		Efficiencies = {
-			Min = 1.5,	-- Best efficiency before this (Gs)
+			Min = 1,	-- Best efficiency before this (Gs)
 			Max = 4,	-- Worst efficiency after this (Gs)
 		},
 		Damages = {
@@ -216,7 +216,7 @@ CrewTypes.Register("Commander", {
 	},
 	GForceInfo = {
 		Efficiencies = {
-			Min = 1.5,		-- Best efficiency before this (Gs)
+			Min = 1,		-- Best efficiency before this (Gs)
 			Max = 4,		-- Worst efficiency after this (Gs)
 		},
 		-- Used instead of Efficiencies while linked to a gun/rack, since loading duty is

--- a/lua/acf/entities/crew_types/crew_types.lua
+++ b/lua/acf/entities/crew_types/crew_types.lua
@@ -58,8 +58,8 @@ end
 CrewTypes.Register("Loader", {
 	Name        = "Loader",
 	Icon		= "icon16/wand.png",
-	Description = "Loaders affect the reload rate of your guns. Link them to gun(s). They prefer standing.",
-	ExtraNotes 	= "Loaders can be linked to any gun, but their focus is split between each. Viewing loaders with the acf menu tool will visualize the space they need for peak performance in purple.",
+	Description = "Loaders affect the reload rate of your weapons. Link them to ACF Guns or Missile Racks. They prefer standing poses.",
+	ExtraNotes 	= "Loaders can link to multiple ACF Guns or Missile Racks at once, but this will spread their focus between what they're linked to. Viewing loaders with the ACF Menu tool will visualize the space they need for peak performance in purple.",
 	Cost	= 1,
 	LimitConVar	= {			-- ConVar to limit the number of crew members of this type a player can have
 		Name	= "_acf_crew_loader",
@@ -72,11 +72,11 @@ CrewTypes.Register("Loader", {
 		Max = 90,			-- Worst efficiency after this angle (Degs)
 	},
 	GForceInfo = {
-		Efficiencies = {	-- Specifying this table enables G force efficiency calculations
-			Min = 0,		-- Best efficiency before this (Gs)
+		Efficiencies = {	-- Specifying this table enables G-force efficiency calculations
+			Min = 0.5,		-- Best efficiency before this (Gs)
 			Max = 3,		-- Worst efficiency after this (Gs)
 		},
-		Damages = {			-- Specifying this table enables G force damage calculations
+		Damages = {			-- Specifying this table enables G-force damage calculations
 			Min = 5,		-- Damage starts being applied after this (Gs)
 			Max = 9,		-- Instant death after this (Gs)
 		}
@@ -110,8 +110,8 @@ CrewTypes.Register("Loader", {
 CrewTypes.Register("Gunner", {
 	Name        = "Gunner",
 	Icon		= "icon16/gun.png",
-	Description = "Gunners affect the accuracy of your gun. Link them to acf turret rings or baseplates. They prefer sitting.",
-	ExtraNotes	= "Gunners can only be linked to one type of gun and their focus does not change.",
+	Description = "Gunners provide control over weaponized turrets, letting them update their aim freely. Link them to ACF Horizontal Turrets. They prefer sitting poses.",
+	ExtraNotes	= "Gunners can only be linked to one turret. Their control benefit can propagate to Vertical turrets which are parented to the Horizontal turret if the cumulative mass of the Horizontal turret is less than 250kg, the Gunner is directly parented to the Horizontal turret, or if the Gunner is also linked to a Remote Turret Controller.",
 	Cost	= 1,
 	LimitConVar	= {
 		Name	= "_acf_crew_gunner",
@@ -125,8 +125,8 @@ CrewTypes.Register("Gunner", {
 	},
 	GForceInfo = {
 		Efficiencies = {
-			Min = 0,	-- Best efficiency before this (Gs)
-			Max = 3,	-- Worst efficiency after this (Gs)
+			Min = 1.5,	-- Best efficiency before this (Gs)
+			Max = 4,	-- Worst efficiency after this (Gs)
 		},
 		Damages = {
 			Min = 5,	-- Damage starts being applied after this (Gs)
@@ -138,12 +138,6 @@ CrewTypes.Register("Gunner", {
 			CanLink = function(Crew, Target) -- Called when a crew member tries to link to an entity
 				if CheckCount(Crew) then return false, "Gunners can only link to one entity." end
 				if Target.Turret == "Turret-V" then return false, "Gunners cannot link to vertical drives." end
-				return true, "Crew linked."
-			end
-		},
-		acf_baseplate = {
-			CanLink = function(Crew) -- Called when a crew member tries to link to an entity
-				if CheckCount(Crew, "acf_baseplate") then return false, "Gunners can only link to one acf_baseplate." end
 				return true, "Crew linked."
 			end
 		}
@@ -162,8 +156,8 @@ CrewTypes.Register("Gunner", {
 CrewTypes.Register("Driver", {
 	Name        = "Driver",
 	Icon		= "icon16/car.png",
-	Description = "Drivers affect the fuel efficiency of your engines. Link them to acf baseplates. They prefer sitting.",
-	ExtraNotes	= "Drivers can be linked to any engine and their focus does not change.",
+	Description = "Drivers permit gearboxes to apply torque to wheels at full effect. Link them to ACF Baseplates. They prefer sitting poses.",
+	ExtraNotes	= "Drivers affect all gearboxes on a contraption.",
 	Cost	= 1,
 	LimitConVar	= {
 		Name	= "_acf_crew_driver",
@@ -177,8 +171,8 @@ CrewTypes.Register("Driver", {
 	},
 	GForceInfo = {
 		Efficiencies = {
-			Min = 0,	-- Best efficiency before this (Gs)
-			Max = 3,	-- Worst efficiency after this (Gs)
+			Min = 1.5,	-- Best efficiency before this (Gs)
+			Max = 4,	-- Worst efficiency after this (Gs)
 		},
 		Damages = {
 			Min = 5,	-- Damage starts being applied after this (Gs)
@@ -207,8 +201,8 @@ CrewTypes.Register("Driver", {
 CrewTypes.Register("Commander", {
 	Name        = "Commander",
 	Icon		= "icon16/medal_gold_1.png",
-	Description = "Commanders coordinate the crew. Works without linking. They prefer sitting.",
-	ExtraNotes 	= "You can link them to work like gunners/loaders to operate a RWS for example. However, this reduces their focus and their ability to command the other crew.",
+	Description = "Commanders coordinate the crew, providing an efficiency bonus, which works without linking. They prefer sitting poses.",
+	ExtraNotes 	= "Commanders can additionally be linked to ACF Horizontal Turrets to serve as Gunners, or to ACF Guns or Missile Racks to serve as Loaders. However, more tasks reduces their focus to put towards each individual task, and their ability to coordinate other crew members.",
 	Cost	= 2,
 	LimitConVar	= {
 		Name	= "_acf_crew_commander",
@@ -222,7 +216,13 @@ CrewTypes.Register("Commander", {
 	},
 	GForceInfo = {
 		Efficiencies = {
-			Min = 0,		-- Best efficiency before this (Gs)
+			Min = 1.5,		-- Best efficiency before this (Gs)
+			Max = 4,		-- Worst efficiency after this (Gs)
+		},
+		-- Used instead of Efficiencies while linked to a gun/rack, since loading duty is
+		-- as sensitive to movement as an actual Loader's, regardless of Commander's usual tolerance
+		LoaderEfficiencies = {
+			Min = 0.5,		-- Best efficiency before this (Gs)
 			Max = 3,		-- Worst efficiency after this (Gs)
 		},
 		Damages = {
@@ -279,8 +279,8 @@ CrewTypes.Register("Commander", {
 CrewTypes.Register("Pilot", {
 	Name        = "Pilot",
 	Icon		= "icon16/weather_clouds.png",
-	Description = "Pilots can sustain higher G tolerances but weigh more (life support systems and G suits). You should only use these on aircraft.",
-	ExtraNotes 	= "Pilots do not affect anything at the moment.",
+	Description = "Pilots can sustain higher G-forces than other crew types, but weigh more to represent life support systems and a G-suit. Only usable on aircraft.",
+	ExtraNotes 	= "Pilots can perform either Driver duty when linked to an ACF Baseplate or Gunner duty when linked to an ACF Horizontal Turret, but can only perform one job.",
 	Cost	= 5,
 	LimitConVar	= {
 		Name	= "_acf_crew_pilot",
@@ -295,14 +295,6 @@ CrewTypes.Register("Pilot", {
 		}
 	},
 	LinkHandlers = {
-		acf_gun = {
-			OnLink = function(Crew)	Crew.ShouldScan = CheckCount(Crew, "acf_gun") or CheckCount(Crew, "acf_rack") end,
-			OnUnlink = function(Crew) Crew.ShouldScan = CheckCount(Crew, "acf_gun") or CheckCount(Crew, "acf_rack") end,
-		},
-		acf_rack = {
-			OnLink = function(Crew)	Crew.ShouldScan = CheckCount(Crew, "acf_gun") or CheckCount(Crew, "acf_rack") end,
-			OnUnlink = function(Crew) Crew.ShouldScan = CheckCount(Crew, "acf_gun") or CheckCount(Crew, "acf_rack") end,
-		},
 		acf_turret = {
 			CanLink = function(Crew, Target) -- Called when a crew member tries to link to an entity
 				if CheckCount(Crew) then return false, "Pilot can only link to one entity." end
@@ -312,7 +304,7 @@ CrewTypes.Register("Pilot", {
 		},
 		acf_baseplate = {
 			CanLink = function(Crew) -- Called when a crew member tries to link to an entity
-				if CheckCount(Crew, "acf_baseplate") then return false, "Pilot can only link to one acf_baseplate." end
+				if CheckCount(Crew) then return false, "Pilot can only link to one entity." end
 				return true, "Crew linked."
 			end
 		}

--- a/lua/acf/entities/turrets/turrets.lua
+++ b/lua/acf/entities/turrets/turrets.lua
@@ -46,7 +46,7 @@ do	-- Turret drives
 		LimitConVar	= {
 			Name	= "_acf_turret",
 			Amount	= 20,
-			Text	= "Maximum number of ACF turrets a player can create."
+			Text	= "Maximum number of ACF Turrets a player can create."
 		},
 		GetMass		= function(Data, Size)
 			return math.Round(math.max(Data.Mass * (Size / Data.Size.Base), 5) ^ 1.5, 1)
@@ -368,7 +368,7 @@ do	-- Turret motors
 		LimitConVar	= {
 			Name	= "_acf_turret_motor",
 			Amount	= 20,
-			Text	= "Maximum number of ACF turret components a player can create."
+			Text	= "Maximum number of ACF Turret Motors a player can create."
 		},
 
 		GetTorque	= function(Data, CompSize)
@@ -467,7 +467,7 @@ do	-- Turret gyroscopes
 		LimitConVar	= {
 			Name	= "_acf_turret_gyro",
 			Amount	= 20,
-			Text	= "Maximum number of ACF turret gyros a player can create."
+			Text	= "Maximum number of ACF Turret Gyros a player can create."
 		},
 	})
 
@@ -519,7 +519,7 @@ do	-- Turret computers
 		LimitConVar	= {
 			Name	= "_acf_turret_computer",
 			Amount	= 4,
-			Text	= "Maximum number of ACF turret computers a player can create."
+			Text	= "Maximum number of ACF Turret Computers a player can create."
 		},
 	})
 
@@ -589,4 +589,52 @@ do	-- Turret computers
 			},
 		})
 	end
+end
+
+do	-- Turret Controllers
+	Turrets.Register("5-Controller", {
+		Name		= "Turret Controllers",
+		SpawnModel  = "models/props_c17/tv_monitor01.mdl",
+		Description	= "#acf.descs.controllers",
+		Entity		= "acf_turret_controller",
+		CreateMenu	= ACF.CreateTurretControllerMenu,
+	})
+
+	Turrets.RegisterItem("Remote", "5-Controller", {
+		Name			= "Remote Turret Controller",
+		Description		= "#acf.descs.controllers.remote",
+		Model			= "models/props_c17/tv_monitor01.mdl",
+		IsRemote		= true,
+		LimitConVar		= {
+			Name	= "_acf_turret_controller_remote",
+			Amount	= 2,
+			Text	= "Maximum number of ACF Remote Turret Controllers a player can create."
+		},
+
+		Preview			= {
+			FOV = 90,
+		},
+
+		Mass			= 15,
+		Cost			= 10,
+	})
+
+	Turrets.RegisterItem("Lightweight", "5-Controller", {
+		Name			= "Lightweight Turret Controller",
+		Description		= "#acf.descs.controllers.lightweight",
+		Model			= "models/props_lab/powerbox02c.mdl",
+		IsRemote		= false,
+		LimitConVar		= {
+			Name	= "_acf_turret_controller_lightweight",
+			Amount	= 2,
+			Text	= "Maximum number of ACF Lightweight Turret Controllers a player can create."
+		},
+
+		Preview			= {
+			FOV = 90,
+		},
+
+		Mass			= 10,
+		Cost			= 5,
+	})
 end

--- a/lua/acf/menu/items_cl/settings.lua
+++ b/lua/acf/menu/items_cl/settings.lua
@@ -94,6 +94,16 @@ do -- Clientside settings
 
 			return Value
 		end)
+
+		Base:AddLabel("#acf.menu.settings.effects_visual_elements.crew_revive")
+		local CrewSupplyColor = Base:AddPanel("DColorMixer")
+		CrewSupplyColor:SetColor(ACF.CrewSupplyColor)
+		CrewSupplyColor:SetClientData("CrewSupplyColor", "ValueChanged")
+		CrewSupplyColor:DefineSetter(function(_, _, _, Value)
+			ACF.CrewSupplyColor = Value
+
+			return Value
+		end)
 	end)
 
 	ACF.AddClientSettings(201, "#acf.menu.settings.legal_checks", function(Base)

--- a/lua/acf/menu/operations/acf_menu.lua
+++ b/lua/acf/menu/operations/acf_menu.lua
@@ -380,6 +380,7 @@ ACF.CreateMenuOperation("1-Turret", "turret")
 ACF.CreateMenuOperation("2-Motor", "turret motor")
 ACF.CreateMenuOperation("3-Gyro", "turret gyroscope")
 ACF.CreateMenuOperation("4-Computer", "turret computer")
+ACF.CreateMenuOperation("5-Controller", "turret controller")
 
 local Notify = ACF.Utilities.Notify
 ACF.CreateMenuOperation("Baseplate", "baseplate", nil, {

--- a/lua/acf/persisted_vars/vars_cl.lua
+++ b/lua/acf/persisted_vars/vars_cl.lua
@@ -4,6 +4,7 @@
 ACF.PersistClientData("Volume", 0.5)
 ACF.PersistClientData("AmmoSupplyColor", Color(255, 255, 0, 10))
 ACF.PersistClientData("FuelSupplyColor", Color(76, 201, 250, 10))
+ACF.PersistClientData("CrewSupplyColor", Color(255, 80, 200, 10))
 ACF.PersistClientData("DualClutch", false)
 
 -- Crate projectile counts

--- a/lua/entities/acf_baseplate/modules/crew.lua
+++ b/lua/entities/acf_baseplate/modules/crew.lua
@@ -1,27 +1,16 @@
 local ACF      		= ACF
 
-function ENT:UpdateAccuracyMod()
-    self.CrewsByType = self.CrewsByType or {}
-    local Sum1, Count1 = ACF.WeightedLinkSum(self.CrewsByType.Gunner or {}, function(Crew) return Crew.TotalEff end)
-    local Sum2, Count2 = ACF.WeightedLinkSum(self.CrewsByType.Commander or {}, function(Crew) return Crew.TotalEff end)
-    local Sum3, Count3 = ACF.WeightedLinkSum(self.CrewsByType.Pilot or {}, function(Crew) return Crew.TotalEff end)
-    local Sum, Count = Sum1 + Sum2 + Sum3, Count1 + Count2 + Count3
-    local Val = (Count > 0) and (Sum / Count) or 0
-    self.AccuracyCrewMod = math.Clamp(Val, ACF.CrewFallbackCoef, 1)
-    return self.AccuracyCrewMod
-end
-
-function ENT:UpdateFuelMod()
+function ENT:UpdateDriverMod()
     self.CrewsByType = self.CrewsByType or {}
     local Sum1, Count1 = ACF.WeightedLinkSum(self.CrewsByType.Driver or {}, function(Crew) return Crew.TotalEff end)
     local Sum2, Count2 = ACF.WeightedLinkSum(self.CrewsByType.Pilot or {}, function(Crew) return Crew.TotalEff end)
     local Sum, Count = Sum1 + Sum2, Count1 + Count2
     local Val = (Count > 0) and (Sum / Count) or 0
-    self.FuelCrewMod = math.Clamp(Val, ACF.CrewFallbackCoef, 1)
+    self.DriverCrewMod = (Val >= ACF.DriverEfficiencyThreshold) and 1 or ACF.CrewFallbackCoef
     if self:ACF_GetUserVar("BaseplateType").Name == "Recreational" then
-        self.FuelCrewMod = 1 -- Recreational baseplates have no fuel consumption
+        self.DriverCrewMod = 1 -- Recreational baseplates are meant to not require crew
     end
-    return self.FuelCrewMod
+    return self.DriverCrewMod
 end
 
 function ENT:EnforceLooped()

--- a/lua/entities/acf_baseplate/modules/spawning.lua
+++ b/lua/entities/acf_baseplate/modules/spawning.lua
@@ -69,8 +69,7 @@ function ENT:ACF_PostSpawn(Owner, _, _, ClientData)
 		timer.Remove("ACFPhysicalChecks" .. self:EntIndex())
 	end)
 
-	ACF.AugmentedTimer(function(cfg) self:UpdateAccuracyMod(cfg) end, function() return IsValid(self) end, nil, {MinTime = 0.1, MaxTime = 0.25})
-	ACF.AugmentedTimer(function(cfg) self:UpdateFuelMod(cfg) end, function() return IsValid(self) end, nil, {MinTime = 0.1, MaxTime = 0.25})
+	ACF.AugmentedTimer(function(cfg) self:UpdateDriverMod(cfg) end, function() return IsValid(self) end, nil, {MinTime = 0.1, MaxTime = 0.25})
 	ACF.AugmentedTimer(function(cfg) self:EnforceLooped(cfg) end, function() return IsValid(self) end, nil, {MinTime = 0.1, MaxTime = 0.25})
 	ACF.ActiveBaseplatesTable[self] = true
 	table.insert(ACF.ActiveBaseplatesArray, self)

--- a/lua/entities/acf_crew/init.lua
+++ b/lua/entities/acf_crew/init.lua
@@ -386,16 +386,28 @@ do -- Random timer stuff
 		-- debugoverlay.Cross(NewPos, 4, 1, Red, true)
 		local GForce = ACF.UpdateGForceTracker(SelfTbl.GForceTracker, NewPos, SampleRate)
 
-		-- If specified, affect crew ergonomics based on G forces
+		-- If specified, affect crew ergonomics based on G-forces
 		local GForceInfo = SelfTbl.CrewType.GForceInfo
 		local Effs = GForceInfo.Efficiencies
+
+		-- Commanders take Loader-accurate G-force penalties while performing a Loader's job,
+		-- since loading duty is just as sensitive to movement regardless of who's doing it
+		if GForceInfo.LoaderEfficiencies then
+			local TargetsByType = SelfTbl.TargetsByType
+			local LinkedToGun = TargetsByType and TargetsByType.acf_gun and next(TargetsByType.acf_gun)
+			local LinkedToRack = TargetsByType and TargetsByType.acf_rack and next(TargetsByType.acf_rack)
+			if LinkedToGun or LinkedToRack then
+				Effs = GForceInfo.LoaderEfficiencies
+			end
+		end
+
 		if Effs then
 			SelfTbl.MoveEff = 1 - ACF.Normalize(GForce, Effs.Min, Effs.Max)
 			WireLib.TriggerOutput(self, "MoveEff", SelfTbl.MoveEff * 100)
 		end
 		WireLib.TriggerOutput(self, "GForce", GForce)
 
-		-- If specified, apply damage to crew based on G forces
+		-- If specified, apply damage to crew based on G-forces
 		local Damages = GForceInfo.Damages
 		if Damages and GForce > Damages.Min and SelfTbl.IsAlive then
 			local Damage = ACF.Normalize(GForce, Damages.Min, Damages.Max) * DeltaTime * SampleRate
@@ -592,6 +604,10 @@ do
 
 		UpdateCrew(Entity, Data, CrewModel, CrewType)
 
+		-- Registered only after UpdateCrew has set Entity.CrewType, so acf_supply's Think never
+		-- sees a crew entity in ACF.ActiveCrews before its CrewType (and thus revive cost) exists
+		ACF.ActiveCrews[Entity] = true
+
 		-- Run randomized timers
 		-- TODO: Fix args
 		ACF.AugmentedTimer(function(cfg) ENT_UpdateUltraLowFreq(Entity, cfg) end, function() return IsEntityValid(Entity) end, nil, {MinTime = 3, MaxTime = 5, Delay = 0.1})
@@ -599,6 +615,7 @@ do
 		ACF.AugmentedTimer(function(cfg) ENT_UpdateMedFreq(Entity, cfg) end, function() return IsEntityValid(Entity) end, nil, {MinTime = 0.5, MaxTime = 1, Delay = 0.1})
 		ACF.AugmentedTimer(function(cfg) ENT_UpdateHighFreq(Entity, cfg) end, function() return IsEntityValid(Entity) end, nil, {MinTime = 0.1, MaxTime = 0.5, Delay = 0.1})
 		ACF.AugmentedTimer(function(cfg) ENT_EnforceLimits(Entity, cfg) end, function() return IsEntityValid(Entity) end, nil, {MinTime = 1, MaxTime = 2, Delay = 0.1})
+		ACF.AugmentedTimer(function(cfg) Entity:RegenerateHealth(cfg) end, function() return IsEntityValid(Entity) end, nil, {MinTime = 9, MaxTime = 11, Delay = 0.1})
 
 		hook.Add("Tick", "GForceCalculation" .. Entity:EntIndex(), function()
 			Entity:EnforceGForces(cfg)
@@ -708,49 +725,87 @@ do
 		self:KillCrew("npc/zombie/zombie_voice_idle6.wav")
 	end
 
-	-- Only meant to be called by gamemodes like AAS. This function isn't called otherwise.
+	-- Fully revives a dead crew member. Called by gamemodes like AAS, and by acf_supply when
+	-- resupplying a dead crew member in range.
 	function ENT:Restore()
 		self.ACF.Health = self.ACF.MaxHealth
 		self.IsAlive = true
 		self:SetMaterial(self.MaterialPath or "") -- Reset to default material
+		self:SetColor(Color(255, 255, 255, 255)) -- Reset the flesh-white tint KillCrew applies
+		self:UpdateOverlay()
 	end
 
-	--- Attempts to replace self with another crew member
-	function ENT:ReplaceCrew()
+	function ENT:RegenerateHealth()
+		if not self.IsAlive then return end
+		if self.ACF.Health >= self.ACF.MaxHealth then return end
+		if ACF.IsContraptionInCombat(self) then return end
+
+		self.ACF.Health = math.min(self.ACF.MaxHealth, self.ACF.Health + self.ACF.MaxHealth * ACF.CrewRegenFraction)
+		self:UpdateOverlay()
+	end
+
+	--- Finds the best live candidate to replace self, or nil if none exists.
+	--- The least important (highest CrewPriority number) survivor is picked.
+	function ENT:FindReplacementCandidate()
 		local Contraption = self:CFW_GetContraption()
-		if Contraption == nil then return end 				-- No Contraption to replace crew in
-		if Contraption.CrewsByPriority == nil then return end 	-- No crew to replace with
-		if not self.ToBeReplaced and self.ReplaceSelf then
-			self.ToBeReplaced = true									-- Mark self for replacement
+		if Contraption == nil then return nil end
+		if Contraption.CrewsByPriority == nil then return nil end
 
-			-- Only consider "lower" priority crews
-			local offset = self.ReplacedOnlyLower and 1 or 0
-			for i = self.CrewPriority + offset, ACF.CrewRepPrioMax do
-				local OtherCrews = Contraption.CrewsByPriority[i] or {}
-				for Other in pairs(OtherCrews) do									-- For each crew of that priority
-					local NotMe = Other ~= self and IsValid(Other) 						-- Valid crew that isn't us
-					local NotBusy = not Other.ToReplace									-- Other isn't replacing someone else
-					local Alive = Other.ACF.Health and Other.ACF.Health > 0				-- Other is alive
-					local Replaceable = Other.ReplaceOthers								-- Other can be replaced
-					if NotMe and NotBusy and Alive and Replaceable then
-						Other.ToReplace = true 											-- Other is now replacing someone (us)
-
-						-- Calculate replacement time
-						local ReplacementDist = self:GetPos():Distance(Other:GetPos())
-						local ReplacementTime = ACF.CrewRepTimeBase + ACF.CrewRepDistToTime * ReplacementDist
-						TimerSimple(ReplacementTime, function()
-							Other.ToReplace = false
-							self.ToBeReplaced = false
-
-							if IsValid(self) then
-								self:SwapCrew(Other)
-							end
-						end)
-
-						return
-					end
+		local offset = self.ReplacedOnlyLower and 1 or 0
+		for i = ACF.CrewRepPrioMax, self.CrewPriority + offset, -1 do
+			local OtherCrews = Contraption.CrewsByPriority[i] or {}
+			for Other in pairs(OtherCrews) do
+				local NotMe = Other ~= self and IsValid(Other)
+				local NotBusy = not Other.ToReplace
+				local Alive = Other.ACF.Health and Other.ACF.Health > 0
+				local Replaceable = Other.ReplaceOthers
+				if NotMe and NotBusy and Alive and Replaceable then
+					return Other
 				end
 			end
+		end
+
+		return nil
+	end
+
+	--- Attempts to replace self with another crew member. Searching for a candidate and
+	--- claiming it happen atomically here; the swap itself is only ever performed by
+	--- AttemptSwap after the move delay, which always re-searches rather than trusting
+	--- that the originally claimed candidate is still valid once the delay has passed.
+	function ENT:ReplaceCrew()
+		if self.ToBeReplaced or not self.ReplaceSelf then return end
+		self.ToBeReplaced = true
+
+		local Other = self:FindReplacementCandidate()
+		if Other == nil then
+			-- No candidate found anywhere right now
+			self.ToBeReplaced = false
+			return
+		end
+
+		Other.ToReplace = true
+
+		local ReplacementDist = self:GetPos():Distance(Other:GetPos())
+		local ReplacementTime = ACF.CrewRepTimeBase + ACF.CrewRepDistToTime * ReplacementDist
+		TimerSimple(ReplacementTime, function() self:AttemptSwap(Other) end)
+	end
+
+	--- Runs after the move delay elapses. Other is only a hint of who was originally
+	--- claimed. Both self and Other are re-validated here since either may have changed
+	--- state during the wait (died, got healed, got claimed by something else, etc);
+	--- if the original candidate no longer works, the whole search restarts fresh.
+	function ENT:AttemptSwap(Other)
+		if IsValid(Other) then Other.ToReplace = false end
+		self.ToBeReplaced = false
+
+		if not IsValid(self) then return end
+		if self.IsAlive then return end -- self no longer needs replacing (e.g. got healed)
+
+		local OtherStillValid = IsValid(Other) and Other.ACF.Health and Other.ACF.Health > 0
+		if OtherStillValid then
+			self:SwapCrew(Other)
+		else
+			self:ReplaceCrew()
 		end
 	end
 
@@ -962,10 +1017,12 @@ do
 		if not Target.Crews then Target.Crews = {} end -- Safely make sure the link Target has a crew list
 		if Target.Crews[Crew] then return false, "This entity is already linked to this crewmate!" end
 		if Crew.Targets[Target] then return false, "This entity is already linked to this crewmate!" end
-		if Crew:GetPos():DistToSqr(Target:GetPos()) > MaxDistance then return false, "This entity is too far away from this crewmate!" end
-		if not Crew.CrewType.LinkHandlers[Target:GetClass()] then return false, "This entity cannot be linked with this occupation" end
 
 		local Handlers = Crew.CrewType.LinkHandlers[Target:GetClass()]
+		if not Handlers then return false, "This entity cannot be linked with this occupation" end
+
+		if Crew:GetPos():DistToSqr(Target:GetPos()) > MaxDistance then return false, "This entity is too far away from this crewmate!" end
+
 		if Handlers.CanLink then return Handlers.CanLink(Crew, Target) end
 		return true, "Crew linked."
 	end
@@ -1089,6 +1146,8 @@ do
 	function ENT:OnRemove()
 		local CrewModel = self.CrewModel
 		local CrewType = self.CrewType
+
+		ACF.ActiveCrews[self] = nil
 
 		HookRun("ACF_OnEntityLast", "acf_crew", self, CrewModel, CrewType)
 

--- a/lua/entities/acf_crew/init.lua
+++ b/lua/entities/acf_crew/init.lua
@@ -735,10 +735,15 @@ do
 	-- Timer only runs while the crew actually needs healing; DamageCrew re-arms it. In-combat
 	-- has no discrete end event, so it stays a cheap in-body check instead of a Depends condition
 	function ENT:StartRegenTimer()
+		if self.RegenTimerActive then return end
+		self.RegenTimerActive = true
+
 		local Entity = self
 
 		ACF.AugmentedTimer(function(cfg) Entity:RegenerateHealth(cfg) end, function()
-			return IsEntityValid(Entity) and Entity.IsAlive and Entity.ACF.Health < Entity.ACF.MaxHealth
+			local Needed = IsEntityValid(Entity) and Entity.IsAlive and Entity.ACF.Health < Entity.ACF.MaxHealth
+			if not Needed then Entity.RegenTimerActive = false end
+			return Needed
 		end, nil, {MinTime = 10, MaxTime = 10, Delay = 0.1})
 	end
 

--- a/lua/entities/acf_crew/init.lua
+++ b/lua/entities/acf_crew/init.lua
@@ -390,8 +390,7 @@ do -- Random timer stuff
 		local GForceInfo = SelfTbl.CrewType.GForceInfo
 		local Effs = GForceInfo.Efficiencies
 
-		-- Commanders take Loader-accurate G-force penalties while performing a Loader's job,
-		-- since loading duty is just as sensitive to movement regardless of who's doing it
+		-- Commanders take Loader-accurate G-force penalties while performing Loader duty
 		if GForceInfo.LoaderEfficiencies then
 			local TargetsByType = SelfTbl.TargetsByType
 			local LinkedToGun = TargetsByType and TargetsByType.acf_gun and next(TargetsByType.acf_gun)
@@ -604,8 +603,7 @@ do
 
 		UpdateCrew(Entity, Data, CrewModel, CrewType)
 
-		-- Registered only after UpdateCrew has set Entity.CrewType, so acf_supply's Think never
-		-- sees a crew entity in ACF.ActiveCrews before its CrewType (and thus revive cost) exists
+		-- Registered after UpdateCrew so Entity.CrewType always exists by the time this is visible
 		ACF.ActiveCrews[Entity] = true
 
 		-- Run randomized timers
@@ -615,7 +613,7 @@ do
 		ACF.AugmentedTimer(function(cfg) ENT_UpdateMedFreq(Entity, cfg) end, function() return IsEntityValid(Entity) end, nil, {MinTime = 0.5, MaxTime = 1, Delay = 0.1})
 		ACF.AugmentedTimer(function(cfg) ENT_UpdateHighFreq(Entity, cfg) end, function() return IsEntityValid(Entity) end, nil, {MinTime = 0.1, MaxTime = 0.5, Delay = 0.1})
 		ACF.AugmentedTimer(function(cfg) ENT_EnforceLimits(Entity, cfg) end, function() return IsEntityValid(Entity) end, nil, {MinTime = 1, MaxTime = 2, Delay = 0.1})
-		ACF.AugmentedTimer(function(cfg) Entity:RegenerateHealth(cfg) end, function() return IsEntityValid(Entity) end, nil, {MinTime = 9, MaxTime = 11, Delay = 0.1})
+		Entity:StartRegenTimer()
 
 		hook.Add("Tick", "GForceCalculation" .. Entity:EntIndex(), function()
 			Entity:EnforceGForces(cfg)
@@ -725,8 +723,7 @@ do
 		self:KillCrew("npc/zombie/zombie_voice_idle6.wav")
 	end
 
-	-- Fully revives a dead crew member. Called by gamemodes like AAS, and by acf_supply when
-	-- resupplying a dead crew member in range.
+	-- Fully revives a dead crew member. Called by gamemodes like AAS and by acf_supply.
 	function ENT:Restore()
 		self.ACF.Health = self.ACF.MaxHealth
 		self.IsAlive = true
@@ -735,9 +732,17 @@ do
 		self:UpdateOverlay()
 	end
 
+	-- Timer only runs while the crew actually needs healing; DamageCrew re-arms it. In-combat
+	-- has no discrete end event, so it stays a cheap in-body check instead of a Depends condition
+	function ENT:StartRegenTimer()
+		local Entity = self
+
+		ACF.AugmentedTimer(function(cfg) Entity:RegenerateHealth(cfg) end, function()
+			return IsEntityValid(Entity) and Entity.IsAlive and Entity.ACF.Health < Entity.ACF.MaxHealth
+		end, nil, {MinTime = 10, MaxTime = 10, Delay = 0.1})
+	end
+
 	function ENT:RegenerateHealth()
-		if not self.IsAlive then return end
-		if self.ACF.Health >= self.ACF.MaxHealth then return end
 		if ACF.IsContraptionInCombat(self) then return end
 
 		self.ACF.Health = math.min(self.ACF.MaxHealth, self.ACF.Health + self.ACF.MaxHealth * ACF.CrewRegenFraction)
@@ -768,10 +773,8 @@ do
 		return nil
 	end
 
-	--- Attempts to replace self with another crew member. Searching for a candidate and
-	--- claiming it happen atomically here; the swap itself is only ever performed by
-	--- AttemptSwap after the move delay, which always re-searches rather than trusting
-	--- that the originally claimed candidate is still valid once the delay has passed.
+	--- Attempts to replace self with another crew member. AttemptSwap re-validates the
+	--- candidate after the move delay rather than trusting it's still valid.
 	function ENT:ReplaceCrew()
 		if self.ToBeReplaced or not self.ReplaceSelf then return end
 		self.ToBeReplaced = true
@@ -790,10 +793,8 @@ do
 		TimerSimple(ReplacementTime, function() self:AttemptSwap(Other) end)
 	end
 
-	--- Runs after the move delay elapses. Other is only a hint of who was originally
-	--- claimed. Both self and Other are re-validated here since either may have changed
-	--- state during the wait (died, got healed, got claimed by something else, etc);
-	--- if the original candidate no longer works, the whole search restarts fresh.
+	--- Runs after the move delay. Re-validates both sides in case either changed state during
+	--- the wait, restarting the search if Other no longer works.
 	function ENT:AttemptSwap(Other)
 		if IsValid(Other) then Other.ToReplace = false end
 		self.ToBeReplaced = false
@@ -836,6 +837,8 @@ do
 
 		if NewHealth == 0 and SelfTbl.IsAlive then
 			self:KillCrew(sound)
+		elseif NewHealth > 0 and NewHealth < SelfACF.MaxHealth then
+			self:StartRegenTimer()
 		end
 	end
 	ENT.DamageCrew = ENT_DamageCrew

--- a/lua/entities/acf_engine/init.lua
+++ b/lua/entities/acf_engine/init.lua
@@ -229,20 +229,6 @@ local function SetActive(Entity, Value, EntTbl)
 	Entity:UpdateOutputs(EntTbl)
 end
 
-do -- Random timer crew stuff
-	function ENT:FindPropagator()
-		local Temp = self:GetParent()
-		if IsValid(Temp) and Temp:GetClass() == "acf_baseplate" then return Temp end
-		return nil
-	end
-
-	function ENT:UpdateFuelMod(cfg)
-		local Propagator = self:FindPropagator(cfg)
-		local Val = Propagator and Propagator.FuelCrewMod or 0
-		self.FuelCrewMod = math.Clamp(Val, ACF.CrewFallbackCoef, 1)
-		return self.FuelCrewMod
-	end
-end
 --===============================================================================================--
 
 do -- Spawn and Update functions
@@ -409,8 +395,6 @@ do -- Spawn and Update functions
 		if Class.OnSpawn then
 			Class.OnSpawn(Entity, Data, Class, Engine)
 		end
-
-		ACF.AugmentedTimer(function(cfg) Entity:UpdateFuelMod(cfg) end, function() return IsEntityValid(Entity) end, nil, {MinTime = 0.1, MaxTime = 0.25})
 
 		hook.Run("ACF_OnSpawnEntity", "acf_engine", Entity, Data, Class, Engine)
 
@@ -721,10 +705,10 @@ function ENT:GetConsumption(Throttle, RPM, FuelTank, SelfTbl)
 	if not IsEntityValid(FuelTank) then return 0 end
 
 	if SelfTbl.FuelType == "Electric" then
-		return Throttle * SelfTbl.FuelUse * SelfTbl.Torque * RPM * 1.05e-4 / SelfTbl.FuelCrewMod
+		return Throttle * SelfTbl.FuelUse * SelfTbl.Torque * RPM * 1.05e-4
 	else
 		local IdleConsumption = SelfTbl.PeakPower * 5e2
-		return SelfTbl.FuelUse * (IdleConsumption + Throttle * SelfTbl.Torque * RPM) / FuelTank.FuelDensity / SelfTbl.FuelCrewMod
+		return SelfTbl.FuelUse * (IdleConsumption + Throttle * SelfTbl.Torque * RPM) / FuelTank.FuelDensity
 	end
 end
 

--- a/lua/entities/acf_gearbox/init.lua
+++ b/lua/entities/acf_gearbox/init.lua
@@ -1039,8 +1039,7 @@ do -- Movement -----------------------------------------
 		for Ent, Link in pairs(SelfTbl.Wheels) do
 			-- If the gearbox is braking, always
 			if not Braking or not Link.IsBraking then
-				-- DriverCrewMod only affects torque actually applied to a driven entity, not
-				-- AvailTq itself, so gearbox-to-gearbox transfer above stays unaffected
+				-- Applied here, not to AvailTq, so gearbox-to-gearbox transfer stays unaffected
 				local WheelTorque = Link.ReqTq * AvailTq * DriverCrewMod
 				ReactTq = ReactTq + WheelTorque
 

--- a/lua/entities/acf_gearbox/init.lua
+++ b/lua/entities/acf_gearbox/init.lua
@@ -249,6 +249,14 @@ do -- Spawn and Update functions -----------------------
 		Entity.GearRatio = Entity.Gears[1] * Entity.FinalDrive
 	end
 
+	function ENT:UpdateDriverMod()
+		local Contraption = self:CFW_GetContraption()
+		local Baseplate = Contraption and Contraption.ACF_Baseplate
+		local Val = IsEntityValid(Baseplate) and Baseplate.DriverCrewMod or ACF.CrewFallbackCoef
+		self.DriverCrewMod = Clamp(Val, ACF.CrewFallbackCoef, 1)
+		return self.DriverCrewMod
+	end
+
 	local function CheckRopes(Entity, Target)
 		local NiceName = Target == "Wheels" and "Prop" or "Gearbox"
 		local Ropes = Entity[Target]
@@ -378,6 +386,7 @@ do -- Spawn and Update functions -----------------------
 		Entity.LClutch        = 1
 		Entity.RClutch        = 1
 		Entity.DataStore      = Entities.GetArguments("acf_gearbox")
+		Entity.DriverCrewMod  = ACF.CrewFallbackCoef
 
 		duplicator.ClearEntityModifier(Entity, "mass")
 
@@ -386,6 +395,8 @@ do -- Spawn and Update functions -----------------------
 		if Class.OnSpawn then
 			Class.OnSpawn(Entity, Data, Class, Gearbox)
 		end
+
+		ACF.AugmentedTimer(function(cfg) Entity:UpdateDriverMod(cfg) end, function() return IsEntityValid(Entity) end, nil, {MinTime = 0.1, MaxTime = 0.25})
 
 		hook.Run("ACF_OnSpawnEntity", "acf_gearbox", Entity, Data, Class, Gearbox)
 
@@ -1023,11 +1034,14 @@ do -- Movement -----------------------------------------
 		end
 
 		local Braking = SelfTbl.Braking
+		local DriverCrewMod = SelfTbl.DriverCrewMod or 1
 
 		for Ent, Link in pairs(SelfTbl.Wheels) do
 			-- If the gearbox is braking, always
 			if not Braking or not Link.IsBraking then
-				local WheelTorque = Link.ReqTq * AvailTq
+				-- DriverCrewMod only affects torque actually applied to a driven entity, not
+				-- AvailTq itself, so gearbox-to-gearbox transfer above stays unaffected
+				local WheelTorque = Link.ReqTq * AvailTq * DriverCrewMod
 				ReactTq = ReactTq + WheelTorque
 
 				Link:TransferWheel(Ent, WheelTorque, DeltaTime)
@@ -1046,7 +1060,7 @@ do -- Movement -----------------------------------------
 		end
 
 		for Effector, Link in pairs(SelfTbl.Effectors) do
-			Link:TransferEffector(Effector, Link.ReqTq * AvailTq, DeltaTime, MassRatio, FlyRPM)
+			Link:TransferEffector(Effector, Link.ReqTq * AvailTq * DriverCrewMod, DeltaTime, MassRatio, FlyRPM)
 		end
 
 		SelfTbl.LastActive = Clock.CurTime

--- a/lua/entities/acf_gun/init.lua
+++ b/lua/entities/acf_gun/init.lua
@@ -3,7 +3,6 @@ This is the main server side file for the gun entity.
 
 Crew relevant functions:
 - ENT:UpdateLoadMod(LastTime) -- Updates the load modifier for the gun
-- ENT:UpdateAccuracyMod(LastTime) -- Updates the accuracy modifier for the gun
 - ENT:FindNextCrate(Current, Check, ...) -- Finds the next crate that can be used for the gun
 ]]--
 
@@ -68,7 +67,6 @@ local function CheckUnloadable(v, Gun)
 	return CheckValid(v, Gun) and v:CanRestock() and ACF.BulletEquality(v.BulletData, Gun.BulletData)
 end
 
-local ENT_UpdateAccuracyMod
 local ENT_UpdateLoadMod
 local ENT_FindPropagator
 
@@ -110,8 +108,7 @@ do -- Random timer crew stuff
 		else
 			local Sum1 = ACF.WeightedLinkSum(SelfTbl.CrewsByType.Loader or {}, GetReloadEff, self, SelfTbl.CurrentCrate or self)
 			local Sum2 = ACF.WeightedLinkSum(SelfTbl.CrewsByType.Commander or {}, GetReloadEff, self, SelfTbl.CurrentCrate or self)
-			local Sum3 = ACF.WeightedLinkSum(SelfTbl.CrewsByType.Pilot or {}, GetReloadEff, self, SelfTbl.CurrentCrate or self)
-			SelfTbl.LoadCrewMod = math.Clamp(Sum1 + Sum2 + Sum3, ACF.CrewFallbackCoef, ACF.LoaderMaxBonus)
+			SelfTbl.LoadCrewMod = math.Clamp(Sum1 + Sum2, ACF.CrewFallbackCoef, ACF.LoaderMaxBonus)
 		end
 
 		-- Check space behind breech
@@ -183,16 +180,6 @@ do -- Random timer crew stuff
 		return Temp
 	end
 	ENT.FindPropagator = ENT_FindPropagator
-
-	function ENT_UpdateAccuracyMod(self, Config)
-		local Propagator    = ENT_FindPropagator(self, Config)
-		local SelfTbl       = ENTITY.GetTable(self)
-		local Val = IsValid(Propagator) and ENTITY.GetTable(Propagator).AccuracyCrewMod or 0
-
-		SelfTbl.AccuracyCrewMod = math.Clamp(Val, ACF.CrewFallbackCoef, 1)
-		return SelfTbl.AccuracyCrewMod
-	end
-	ENT.UpdateAccuracyMod = ENT_UpdateAccuracyMod
 
 	function ENT:UpdateRotationFilter()
 		local SelfTbl  = ENTITY.GetTable(self)
@@ -512,7 +499,6 @@ do -- Spawn and Update functions --------------------------------
 		end
 
 		ACF.AugmentedTimer(function(Config) ENT_UpdateLoadMod(Entity, Config) end, function() return IsValid(Entity) end, nil, {MinTime = 0.5, MaxTime = 1})
-		ACF.AugmentedTimer(function(Config) ENT_UpdateAccuracyMod(Entity, Config) end, function() return IsValid(Entity) end, nil, {MinTime = 0.5, MaxTime = 1})
 		ACF.AugmentedTimer(function(Config) Entity:CheckBreechClipping(Config) end, function() return IsValid(Entity) end, nil, {MinTime = 1, MaxTime = 2})
 		ACF.AugmentedTimer(function(Config) Entity:UpdateRotationFilter(Config) end, function() return IsValid(Entity) end, nil, {MinTime = 1, MaxTime = 2})
 
@@ -883,7 +869,7 @@ do -- Metamethods --------------------------------
 			local SpreadScale = ACF.SpreadScale
 			local IaccMult    = math.Clamp(((1 - SpreadScale) / 0.5) * ((SelfTbl.ACF.Health / SelfTbl.ACF.MaxHealth) - 1) + 1, 1, SpreadScale)
 
-			return SelfTbl.Spread * ACF.GunInaccuracyScale * IaccMult / (SelfTbl.AccuracyCrewMod or 1)
+			return SelfTbl.Spread * ACF.GunInaccuracyScale * IaccMult
 		end
 
 		function ENT:Shoot()

--- a/lua/entities/acf_rack/init.lua
+++ b/lua/entities/acf_rack/init.lua
@@ -97,8 +97,7 @@ do
 		else
 			local Sum1 = ACF.WeightedLinkSum(self.CrewsByType.Loader or {}, GetReloadEff, self, self.CurrentCrate or self)
 			local Sum2 = ACF.WeightedLinkSum(self.CrewsByType.Commander or {}, GetReloadEff, self, self.CurrentCrate or self)
-			local Sum3 = ACF.WeightedLinkSum(self.CrewsByType.Pilot or {}, GetReloadEff, self, self.CurrentCrate or self)
-			self.LoadCrewMod = self.LoadCrewModOverride or math.Clamp(Sum1 + Sum2 + Sum3, ACF.CrewFallbackCoef, ACF.LoaderMaxBonus)
+			self.LoadCrewMod = self.LoadCrewModOverride or math.Clamp(Sum1 + Sum2, ACF.CrewFallbackCoef, ACF.LoaderMaxBonus)
 		end
 
 		-- Check space behind breech
@@ -147,21 +146,6 @@ do
 		return self.LoadCrewMod
 	end
 
-	function ENT:FindPropagator()
-		local Temp = self:GetParent()
-		if IsValid(Temp) and Temp:GetClass() == "acf_turret" and Temp.Turret == "Turret-V" then Temp = Temp:GetParent() end
-		if IsValid(Temp) and Temp:GetClass() == "acf_turret" and Temp.Turret == "Turret-H" then return Temp end
-		if IsValid(Temp) and Temp:GetClass() == "acf_baseplate" then return Temp end
-		return nil
-	end
-
-	function ENT:UpdateAccuracyMod(Config)
-		local Propagator = self:FindPropagator(Config)
-		local Val = Propagator and Propagator.AccuracyCrewMod or 0
-
-		self.AccuracyCrewMod = math.Clamp(Val, ACF.CrewFallbackCoef, 1)
-		return self.AccuracyCrewMod
-	end
 
 	function ENT:SetLoadModOverride(Efficiency)
 		self.LoadCrewModOverride = Efficiency
@@ -370,7 +354,6 @@ do -- Spawning and Updating --------------------
 		end
 
 		ACF.AugmentedTimer(function(Config) Rack:UpdateLoadMod(Config) end, function() return IsValid(Rack) end, nil, {MinTime = 0.5, MaxTime = 1})
-		ACF.AugmentedTimer(function(Config) Rack:UpdateAccuracyMod(Config) end, function() return IsValid(Rack) end, nil, {MinTime = 0.5, MaxTime = 1})
 
 		hook.Run("ACF_OnSpawnEntity", "acf_rack", Rack, Data, RackData)
 
@@ -758,7 +741,7 @@ do -- Firing -----------------------------------
 	end
 
 	function ENT:GetSpread()
-		return self.Spread * ACF.GunInaccuracyScale / (self.AccuracyCrewMod or 1)
+		return self.Spread * ACF.GunInaccuracyScale
 	end
 
 	function ENT:Shoot()

--- a/lua/entities/acf_supply/modules/supply.lua
+++ b/lua/entities/acf_supply/modules/supply.lua
@@ -1,15 +1,11 @@
-local ACF               = ACF
-local Utilities         = ACF.Utilities
-local Clock             = Utilities.Clock
-local Sounds            = Utilities.Sounds
-local SupplyDist2       = (ACF.SupplyDistance or 300) * (ACF.SupplyDistance or 300)
-local ContraptionScanRate = 3 -- Seconds between rescans for nearby contraptions to resupply
-
-local SuppliableClasses = {
-	acf_ammo     = true,
-	acf_fueltank = true,
-	acf_crew     = true,
-}
+local ACF           = ACF
+local Utilities     = ACF.Utilities
+local Clock         = Utilities.Clock
+local Sounds        = Utilities.Sounds
+local ActiveCrates  = ACF.AmmoCrates or {}
+local ActiveTanks   = ACF.FuelTanks or {}
+local ActiveCrews   = ACF.ActiveCrews or {}
+local SupplyDist2   = (ACF.SupplyDistance or 300) * (ACF.SupplyDistance or 300)
 
 local function SupplyEffect(Entity, RefilledAmmo, RefilledFuel, RevivedCrew)
 	net.Start("ACF_SupplyEffect")
@@ -62,30 +58,6 @@ local function CanReviveCrew(Supply, Target, Distance2)
 	return Distance2 <= SupplyDist2
 end
 
--- Finds nearby contraptions via FindInSphere instead of scanning every ammo/fuel/crew ent.
--- Standalone ents get a pseudo-contraption (same fallback as Contraption.GetEnts)
-local function RefreshNearbyContraptions(Entity)
-	local Pos = Entity:GetPos()
-	local Nearby = {}
-
-	for _, Ent in ipairs(ents.FindInSphere(Pos, ACF.SupplyDistance)) do
-		if IsValid(Ent) and SuppliableClasses[Ent:GetClass()] then
-			local Contraption = Ent:CFW_GetContraption()
-
-			if not Contraption then
-				-- Cache the pseudo-contraption on the entity so standalone ents (no welds/parents)
-				-- don't get a new one built every rescan
-				Contraption = Ent.ACF_PseudoContraption or ACF.EntitiesToPseudoContraption({Ent})
-				Ent.ACF_PseudoContraption = Contraption
-			end
-
-			Nearby[Contraption] = true
-		end
-	end
-
-	Entity.NearbyContraptions = Nearby
-end
-
 function ENT:Enable()
 	if self.BaseClass.Enable then
 		self.BaseClass.Enable(self)
@@ -93,8 +65,6 @@ function ENT:Enable()
 
 	-- Start thinking when enabled
 	self.LastThink = Clock.CurTime
-	self.NearbyContraptions = self.NearbyContraptions or {}
-	RefreshNearbyContraptions(self)
 	self:NextThink(Clock.CurTime + 1)
 end
 
@@ -122,45 +92,36 @@ function ENT:Think()
 		return true
 	end
 
-	if Now >= (self.NextContraptionScan or 0) then
-		self.NextContraptionScan = Now + ContraptionScanRate
-		RefreshNearbyContraptions(self)
-	end
-
-	-- Search for targets to supply, only within contraptions already known to be nearby
+	-- Search for targets to supply
 	local Pos = self:GetPos()
 	local Recipients, Count = {}, 0
 
-	for Contraption in pairs(self.NearbyContraptions) do
-		local EntsByClass = Contraption.entsbyclass or {}
-
-		for Target in pairs(EntsByClass.acf_ammo or {}) do
-			if IsValid(Target) then
-				local Dist2 = Pos:DistToSqr(Target:GetPos())
-				if CanSupply(self, Target, Dist2) then
-					Count = Count + 1
-					Recipients[Count] = Target
-				end
+	for Target in pairs(ActiveCrates) do
+		if IsValid(Target) then
+			local Dist2 = Pos:DistToSqr(Target:GetPos())
+			if CanSupply(self, Target, Dist2) then
+				Count = Count + 1
+				Recipients[Count] = Target
 			end
 		end
+	end
 
-		for Target in pairs(EntsByClass.acf_fueltank or {}) do
-			if IsValid(Target) then
-				local Dist2 = Pos:DistToSqr(Target:GetPos())
-				if CanSupply(self, Target, Dist2) then
-					Count = Count + 1
-					Recipients[Count] = Target
-				end
+	for Target in pairs(ActiveTanks) do
+		if IsValid(Target) then
+			local Dist2 = Pos:DistToSqr(Target:GetPos())
+			if CanSupply(self, Target, Dist2) then
+				Count = Count + 1
+				Recipients[Count] = Target
 			end
 		end
+	end
 
-		for Target in pairs(EntsByClass.acf_crew or {}) do
-			if IsValid(Target) then
-				local Dist2 = Pos:DistToSqr(Target:GetPos())
-				if CanReviveCrew(self, Target, Dist2) then
-					Count = Count + 1
-					Recipients[Count] = Target
-				end
+	for Target in pairs(ActiveCrews) do
+		if IsValid(Target) then
+			local Dist2 = Pos:DistToSqr(Target:GetPos())
+			if CanReviveCrew(self, Target, Dist2) then
+				Count = Count + 1
+				Recipients[Count] = Target
 			end
 		end
 	end

--- a/lua/entities/acf_supply/modules/supply.lua
+++ b/lua/entities/acf_supply/modules/supply.lua
@@ -1,11 +1,15 @@
-local ACF           = ACF
-local Utilities     = ACF.Utilities
-local Clock         = Utilities.Clock
-local Sounds        = Utilities.Sounds
-local ActiveCrates  = ACF.AmmoCrates or {}
-local ActiveTanks   = ACF.FuelTanks or {}
-local ActiveCrews   = ACF.ActiveCrews or {}
-local SupplyDist2   = (ACF.SupplyDistance or 300) * (ACF.SupplyDistance or 300)
+local ACF               = ACF
+local Utilities         = ACF.Utilities
+local Clock             = Utilities.Clock
+local Sounds            = Utilities.Sounds
+local SupplyDist2       = (ACF.SupplyDistance or 300) * (ACF.SupplyDistance or 300)
+local ContraptionScanRate = 3 -- Seconds between rescans for nearby contraptions to resupply
+
+local SuppliableClasses = {
+	acf_ammo     = true,
+	acf_fueltank = true,
+	acf_crew     = true,
+}
 
 local function SupplyEffect(Entity, RefilledAmmo, RefilledFuel, RevivedCrew)
 	net.Start("ACF_SupplyEffect")
@@ -58,6 +62,30 @@ local function CanReviveCrew(Supply, Target, Distance2)
 	return Distance2 <= SupplyDist2
 end
 
+-- Finds nearby contraptions via FindInSphere instead of scanning every ammo/fuel/crew ent.
+-- Standalone ents get a pseudo-contraption (same fallback as Contraption.GetEnts)
+local function RefreshNearbyContraptions(Entity)
+	local Pos = Entity:GetPos()
+	local Nearby = {}
+
+	for _, Ent in ipairs(ents.FindInSphere(Pos, ACF.SupplyDistance)) do
+		if IsValid(Ent) and SuppliableClasses[Ent:GetClass()] then
+			local Contraption = Ent:CFW_GetContraption()
+
+			if not Contraption then
+				-- Cache the pseudo-contraption on the entity so standalone ents (no welds/parents)
+				-- don't get a new one built every rescan
+				Contraption = Ent.ACF_PseudoContraption or ACF.EntitiesToPseudoContraption({Ent})
+				Ent.ACF_PseudoContraption = Contraption
+			end
+
+			Nearby[Contraption] = true
+		end
+	end
+
+	Entity.NearbyContraptions = Nearby
+end
+
 function ENT:Enable()
 	if self.BaseClass.Enable then
 		self.BaseClass.Enable(self)
@@ -65,6 +93,8 @@ function ENT:Enable()
 
 	-- Start thinking when enabled
 	self.LastThink = Clock.CurTime
+	self.NearbyContraptions = self.NearbyContraptions or {}
+	RefreshNearbyContraptions(self)
 	self:NextThink(Clock.CurTime + 1)
 end
 
@@ -92,36 +122,45 @@ function ENT:Think()
 		return true
 	end
 
-	-- Search for targets to supply
+	if Now >= (self.NextContraptionScan or 0) then
+		self.NextContraptionScan = Now + ContraptionScanRate
+		RefreshNearbyContraptions(self)
+	end
+
+	-- Search for targets to supply, only within contraptions already known to be nearby
 	local Pos = self:GetPos()
 	local Recipients, Count = {}, 0
 
-	for Target in pairs(ActiveCrates) do
-		if IsValid(Target) then
-			local Dist2 = Pos:DistToSqr(Target:GetPos())
-			if CanSupply(self, Target, Dist2) then
-				Count = Count + 1
-				Recipients[Count] = Target
+	for Contraption in pairs(self.NearbyContraptions) do
+		local EntsByClass = Contraption.entsbyclass or {}
+
+		for Target in pairs(EntsByClass.acf_ammo or {}) do
+			if IsValid(Target) then
+				local Dist2 = Pos:DistToSqr(Target:GetPos())
+				if CanSupply(self, Target, Dist2) then
+					Count = Count + 1
+					Recipients[Count] = Target
+				end
 			end
 		end
-	end
 
-	for Target in pairs(ActiveTanks) do
-		if IsValid(Target) then
-			local Dist2 = Pos:DistToSqr(Target:GetPos())
-			if CanSupply(self, Target, Dist2) then
-				Count = Count + 1
-				Recipients[Count] = Target
+		for Target in pairs(EntsByClass.acf_fueltank or {}) do
+			if IsValid(Target) then
+				local Dist2 = Pos:DistToSqr(Target:GetPos())
+				if CanSupply(self, Target, Dist2) then
+					Count = Count + 1
+					Recipients[Count] = Target
+				end
 			end
 		end
-	end
 
-	for Target in pairs(ActiveCrews) do
-		if IsValid(Target) then
-			local Dist2 = Pos:DistToSqr(Target:GetPos())
-			if CanReviveCrew(self, Target, Dist2) then
-				Count = Count + 1
-				Recipients[Count] = Target
+		for Target in pairs(EntsByClass.acf_crew or {}) do
+			if IsValid(Target) then
+				local Dist2 = Pos:DistToSqr(Target:GetPos())
+				if CanReviveCrew(self, Target, Dist2) then
+					Count = Count + 1
+					Recipients[Count] = Target
+				end
 			end
 		end
 	end

--- a/lua/entities/acf_supply/modules/supply.lua
+++ b/lua/entities/acf_supply/modules/supply.lua
@@ -4,14 +4,15 @@ local Clock         = Utilities.Clock
 local Sounds        = Utilities.Sounds
 local ActiveCrates  = ACF.AmmoCrates or {}
 local ActiveTanks   = ACF.FuelTanks or {}
+local ActiveCrews   = ACF.ActiveCrews or {}
 local SupplyDist2   = (ACF.SupplyDistance or 300) * (ACF.SupplyDistance or 300)
-local CombatTimeout = 30 / engine.TickInterval() -- 30 seconds
 
-local function SupplyEffect(Entity, RefilledAmmo, RefilledFuel)
+local function SupplyEffect(Entity, RefilledAmmo, RefilledFuel, RevivedCrew)
 	net.Start("ACF_SupplyEffect")
 		net.WriteEntity(Entity)
 		net.WriteBool(RefilledAmmo)
 		net.WriteBool(RefilledFuel)
+		net.WriteBool(RevivedCrew)
 	net.Broadcast()
 end
 
@@ -21,10 +22,10 @@ local function StopSupplyEffect(Entity)
 	net.Broadcast()
 end
 
-local function SetEffectState(Entity, Active, RefilledAmmo, RefilledFuel)
+local function SetEffectState(Entity, Active, RefilledAmmo, RefilledFuel, RevivedCrew)
 	if Active and not Entity.EffectActive then
 		Entity.EffectActive = true
-		SupplyEffect(Entity, RefilledAmmo, RefilledFuel)
+		SupplyEffect(Entity, RefilledAmmo, RefilledFuel, RevivedCrew)
 	elseif not Active and Entity.EffectActive then
 		Entity.EffectActive = nil
 		StopSupplyEffect(Entity)
@@ -41,11 +42,18 @@ local function CanSupply(Supply, Target, Distance2)
 
 	if (Cap - Amount) <= 0.005 then return false end -- Treat near-full as full to avoid micro top-ups
 
-	-- Check if target's contraption is in combat
-	local TC = Target:CFW_GetContraption()
-	if TC and TC.InCombat and (engine.TickCount() - TC.InCombat) < CombatTimeout then
-		return false -- Still in combat, cannot refill
-	end
+	if ACF.IsContraptionInCombat(Target) then return false end -- Still in combat, cannot refill
+
+	return Distance2 <= SupplyDist2
+end
+
+-- Crew don't have an Amount/Capacity to top up, they're either alive or they need a full revival
+local function CanReviveCrew(Supply, Target, Distance2)
+	if Supply == Target then return false end
+	if Target.Disabled then return false end
+	if Target.IsAlive then return false end
+
+	if ACF.IsContraptionInCombat(Target) then return false end
 
 	return Distance2 <= SupplyDist2
 end
@@ -108,6 +116,16 @@ function ENT:Think()
 		end
 	end
 
+	for Target in pairs(ActiveCrews) do
+		if IsValid(Target) then
+			local Dist2 = Pos:DistToSqr(Target:GetPos())
+			if CanReviveCrew(self, Target, Dist2) then
+				Count = Count + 1
+				Recipients[Count] = Target
+			end
+		end
+	end
+
 	if Count == 0 then
 		SetEffectState(self, false)
 		return true
@@ -121,22 +139,37 @@ function ENT:Think()
 
 	local PerTargetBudget = Budget / Count
 	local UsedBudget = 0
-	local RefilledAmmo, RefilledFuel = false, false
+	local RefilledAmmo, RefilledFuel, RevivedCrew = false, false, false
 
 	for i = 1, Count do
 		local Remaining = self.Amount - UsedBudget
 		if Remaining <= 0 then break end
 
-		local Target   = Recipients[i]
-		local UnitMass = Target:GetUnitMass()
-		local Need     = Target.Capacity - Target.Amount
+		local Target = Recipients[i]
 
 		-- Determine how much mass we can transfer to this target
 		local TransferMass = math.min(PerTargetBudget, Remaining)
 
-		if Target.IsACFAmmoCrate then
+		if Target.IsACFCrew then
+			-- Crew aren't topped up gradually, they're either alive or need a full revival.
+			-- Costs the crew member's own mass, same as any other resource this crate provides
+			local ReviveCost = Target.CrewType and Target.CrewType.Mass or 0
+
+			if TransferMass >= ReviveCost then
+				Target:Restore()
+				RevivedCrew = true
+
+				Sounds.SendSound(self, "items/medshot4.wav", 70, 100, 0.5)
+				Sounds.SendSound(Target, "items/medshot4.wav", 70, 100, 0.5)
+
+				UsedBudget = UsedBudget + ReviveCost
+			end
+		elseif Target.IsACFAmmoCrate then
 			-- For ammo crates: only whole cartridges can be transferred
 			-- If we can't transfer enough mass for a full cartridge, build it up until we can
+
+			local UnitMass = Target:GetUnitMass()
+			local Need     = Target.Capacity - Target.Amount
 
 			local Buffer = (self.MassBuffers[Target] or 0) + TransferMass -- Add mass to buffer
 			local Units  = math.min(math.floor(Buffer / UnitMass), Need) -- Check if we have enough in the buffer for at least one cartridge
@@ -166,7 +199,9 @@ function ENT:Think()
 			end
 		else
 			-- For fuel tanks, transfer any fractional amount. They're liquids after all!
-			local Units = math.min(TransferMass / UnitMass, Need)
+			local UnitMass = Target:GetUnitMass()
+			local Need     = Target.Capacity - Target.Amount
+			local Units    = math.min(TransferMass / UnitMass, Need)
 
 			Target:Consume(-Units)
 			RefilledFuel = true
@@ -184,7 +219,7 @@ function ENT:Think()
 	end
 
 	-- Show effect if we're trying to refill anything
-	SetEffectState(self, true, RefilledAmmo, RefilledFuel)
+	SetEffectState(self, true, RefilledAmmo, RefilledFuel, RevivedCrew)
 
 	if UsedBudget > 0 then
 		self:Consume(UsedBudget)

--- a/lua/entities/acf_turret/init.lua
+++ b/lua/entities/acf_turret/init.lua
@@ -29,18 +29,79 @@ local MaxLinkDistance = ACF.LinkDistance ^ 2
 local UnlinkSound = "physics/metal/metal_box_impact_bullet%s.wav"
 
 do -- Random timer crew stuff
-	local function ReturnCrewTotalEff(Crew) return ENTITY.GetTable(Crew).TotalEff end
-	function ENT:UpdateAccuracyMod()
-		local SelfTbl = ENTITY.GetTable(self)
+	local LightweightMassLimit = 250 -- kg. Turrets at or under this carried mass can be controlled by a shared-parent Gunner, or a Lightweight Turret Controller, without needing to be mounted on it
 
+	--- Whether a single Gunner-role crew member currently renders this turret controlled,
+	--- and whether that control should cascade to vertical drives mounted on it.
+	local function CrewGrantsControl(Turret, Crew)
+		if ENTITY.GetTable(Crew).TotalEff < ACF.GunnerEfficiencyThreshold then return false, false end
+
+		local CrewParent = Crew:GetParent()
+
+		if CrewParent == Turret then return true, true end -- Mounted directly on the turret
+
+		local RemoteController = Crew.RemoteController
+		if IsValid(RemoteController) and RemoteController:IsActive() then return true, true end
+
+		if CrewParent == Turret:GetParent() then -- Shares a parent with the turret
+			local CarriedMass = (Turret.TurretData.TotalMass or 0) + (Turret.ACF.Mass or 0)
+			if CarriedMass <= LightweightMassLimit then return true, true end
+			return true, false -- Controls, but no cascade to vertical drives
+		end
+
+		return false, false
+	end
+
+	--- Renders this turret controlled based on whichever linked Gunner/Commander/Pilot
+	--- currently qualifies, OR-ed with an immediate horizontal ancestor's cascade if this is
+	--- a vertical drive. Each turret only ever sets its own IsControlled, never a sub-turret's,
+	--- to avoid two separate UpdateControlled calls racing to overwrite the same field.
+	--- A Lightweight Turret Controller linked directly to a turret always cascades too, since
+	--- it isn't "riding" the horizontal drive the way a mounted Gunner would be.
+	local function HasActiveLightweightController(Turret)
+		for Controller in pairs(Turret.LightweightControllers or {}) do
+			if IsValid(Controller) and Controller:IsActive() then return true end
+		end
+		return false
+	end
+
+	function ENT:UpdateControlled()
+		local SelfTbl = ENTITY.GetTable(self)
 		SelfTbl.CrewsByType = SelfTbl.CrewsByType or {}
-		local Sum1, Count1 = ACF.WeightedLinkSum(SelfTbl.CrewsByType.Gunner or {}, ReturnCrewTotalEff)
-		local Sum2, Count2 = ACF.WeightedLinkSum(SelfTbl.CrewsByType.Commander or {}, ReturnCrewTotalEff)
-		local Sum3, Count3 = ACF.WeightedLinkSum(SelfTbl.CrewsByType.Pilot or {}, ReturnCrewTotalEff)
-		local Sum, Count = Sum1 + Sum2 + Sum3, Count1 + Count2 + Count3
-		local Val = (Count > 0) and (Sum / Count) or 0
-		SelfTbl.AccuracyCrewMod = math_Clamp(Val, ACF.CrewFallbackCoef, 1)
-		return SelfTbl.AccuracyCrewMod
+
+		local Controlled = HasActiveLightweightController(self)
+
+		if not Controlled then
+			for _, CrewType in ipairs({"Gunner", "Commander", "Pilot"}) do
+				for Crew in pairs(SelfTbl.CrewsByType[CrewType] or {}) do
+					if not IsValid(Crew) then continue end
+
+					local CrewControls = CrewGrantsControl(self, Crew)
+					if CrewControls then Controlled = true end
+				end
+			end
+		end
+
+		if not Controlled and SelfTbl.Turret == "Turret-V" then
+			local Ancestor = SelfTbl.ACF_TurretAncestor
+			if IsValid(Ancestor) and Ancestor.Turret == "Turret-H" then
+				if HasActiveLightweightController(Ancestor) then
+					Controlled = true
+				else
+					for _, CrewType in ipairs({"Gunner", "Commander", "Pilot"}) do
+						for Crew in pairs(Ancestor.CrewsByType and Ancestor.CrewsByType[CrewType] or {}) do
+							if not IsValid(Crew) then continue end
+
+							local _, CrewCascades = CrewGrantsControl(Ancestor, Crew)
+							if CrewCascades then Controlled = true end
+						end
+					end
+				end
+			end
+		end
+
+		SelfTbl.IsControlled = Controlled
+		return Controlled
 	end
 end
 
@@ -155,12 +216,25 @@ do	-- Spawn and Update funcs
 		Entity.DesiredVector = Vector()
 		Entity.DesiredDeg	= 0
 
+		-- Whether a qualifying Gunner/Commander/Pilot (or component) currently controls this
+		-- turret. Only matters while weaponized; an uncontrolled weaponized turret only accepts
+		-- a new aim input once every ACF.UncontrolledAimUpdateInterval seconds after the input
+		-- actually changes, rather than on a fixed clock unrelated to whether anything changed
+		Entity.IsControlled		= false
+		Entity.LastAimInputTime	= 0
+		Entity.LastRequestedDirection = nil
+		Entity.PendingDirection	= nil
+
 		-- Any turrets that happen to get parented to this one, either directly or indirectly
 		-- Mass calculation will stop at this, and instead read whatever that turret has calculated
 		Entity.SubTurrets		= {}
 
 		-- Anything else deemed dynamic when it comes to mass (e.g. ammo, racks, fuel (for whatever reason))
 		Entity.DynamicEntities	= {}
+
+		-- Whether this turret carries a weapon directly, or any sub-turret below it does
+		Entity.HasDirectWeapon	= false
+		Entity.IsWeaponized		= false
 
 		-- Three different mass types to track, all checked differently
 		--[[
@@ -189,8 +263,8 @@ do	-- Spawn and Update funcs
 			Entity.MaxDeg			= Data.MaxDeg
 			Entity.HasArc			= not ((Data.MinDeg == -180) and (Data.MaxDeg == 180))
 		else
-			Entity.MinDeg			= math_max(Data.MinDeg, -85)
-			Entity.MaxDeg			= math_min(Data.MaxDeg, 85)
+			Entity.MinDeg			= math_max(Data.MinDeg, -90)
+			Entity.MaxDeg			= math_min(Data.MaxDeg, 90)
 			Entity.HasArc			= true
 		end
 
@@ -340,7 +414,7 @@ do	-- Spawn and Update funcs
 
 		Entity:UpdateOverlay(true)
 
-		ACF.AugmentedTimer(function(cfg) Entity:UpdateAccuracyMod(cfg) end, function() return IsValid(Entity) end, nil, {MinTime = 0.5, MaxTime = 1})
+		ACF.AugmentedTimer(function(cfg) Entity:UpdateControlled(cfg) end, function() return IsValid(Entity) end, nil, {MinTime = 0.5, MaxTime = 1})
 
 		HookRun("ACF_OnSpawnEntity", "acf_turret", Entity, Data, Class, Turret)
 
@@ -429,16 +503,30 @@ do	-- Spawn and Update funcs
 
 	local function Proxy_ACF_OnParent(self, _, _)
 		local SelfTbl = ENTITY.GetTable(self)
-		if (not IsValid(SelfTbl.ACF_TurretAncestor)) or (not Contraption.HasAncestor(self, SelfTbl.ACF_TurretAncestor)) then self.CFW_OnParented = nil SelfTbl.ACF_TurretAncestor = nil return end
+		local OldAncestor = SelfTbl.ACF_TurretAncestor
+		if not IsValid(OldAncestor) then return end
 
-		SelfTbl.ACF_TurretAncestor:UpdateTurretMass(false)
+		-- Notify the old ancestor even if it's no longer actually an ancestor (e.g. this
+		-- entity just unparented from it), so it can recompute mass/weaponized without us
+		OldAncestor:UpdateTurretMass(false)
+
+		if not Contraption.HasAncestor(self, OldAncestor) then
+			self.CFW_OnParented = nil
+			SelfTbl.ACF_TurretAncestor = nil
+		end
 	end
 
 	local function Proxy_ACF_OnMassChange(self)
 		local SelfTbl = ENTITY.GetTable(self)
-		if (not IsValid(SelfTbl.ACF_TurretAncestor)) or (not Contraption.HasAncestor(self, SelfTbl.ACF_TurretAncestor)) then self.ACF_OnMassChange = nil SelfTbl.ACF_TurretAncestor = nil return end
+		local OldAncestor = SelfTbl.ACF_TurretAncestor
+		if not IsValid(OldAncestor) then return end
 
-		SelfTbl.ACF_TurretAncestor:UpdateTurretMass(false)
+		OldAncestor:UpdateTurretMass(false)
+
+		if not Contraption.HasAncestor(self, OldAncestor) then
+			self.ACF_OnMassChange = nil
+			SelfTbl.ACF_TurretAncestor = nil
+		end
 	end
 
 	local function ParentLink(Turret, Entity, Connect)
@@ -446,14 +534,50 @@ do	-- Spawn and Update funcs
 			Entity.CFW_OnParented		= Proxy_ACF_OnParent
 			Entity.ACF_OnMassChange		= Proxy_ACF_OnMassChange
 			Entity.ACF_TurretAncestor	= Turret
+
+			-- Deletion doesn't reparent, so CFW_OnParented never fires for it. Notify the
+			-- ancestor here too, or a deleted weapon/dynamic entity leaves it stuck stale
+			Entity:CallOnRemove("ACF_TurretAncestorNotify", function()
+				if IsValid(Turret) then Turret:UpdateTurretMass(false) end
+			end)
 		else
 			Entity.CFW_OnParented		= nil
 			Entity.ACF_OnMassChange		= nil
 			Entity.ACF_TurretAncestor	= nil
+
+			if IsValid(Entity) then Entity:RemoveCallOnRemove("ACF_TurretAncestorNotify") end
 		end
 
 		if IsValid(Turret) then
 			Turret:InvalidateClientInfo()
+		end
+	end
+
+	local WeaponTypes = {
+		acf_gun		= true,
+		acf_rack	= true
+	}
+
+	--- Refreshes IsWeaponized from direct children plus each sub-turret's own already-cached
+	--- value, then bubbles a change one hop up to ACF_TurretAncestor. Cheap: never recurses
+	--- into a sub-turret's subtree, only reads the boolean it already computed for itself.
+	local function UpdateWeaponized(Entity, HasDirectWeapon)
+		local Weaponized = HasDirectWeapon
+
+		if not Weaponized then
+			for SubTurret in pairs(Entity.SubTurrets) do
+				if IsValid(SubTurret) and SubTurret.IsWeaponized then
+					Weaponized = true
+					break
+				end
+			end
+		end
+
+		if Entity.IsWeaponized == Weaponized then return end
+		Entity.IsWeaponized = Weaponized
+
+		if IsValid(Entity.ACF_TurretAncestor) then
+			UpdateWeaponized(Entity.ACF_TurretAncestor, Entity.ACF_TurretAncestor.HasDirectWeapon)
 		end
 	end
 
@@ -472,8 +596,12 @@ do	-- Spawn and Update funcs
 
 		local ChildList = GetFilteredChildren(Entity, {}, "acf_turret")
 
+		local HasDirectWeapon = false
+
 		for k in pairs(ChildList) do
 			local Class = k:GetClass()
+
+			if WeaponTypes[Class] then HasDirectWeapon = true end
 
 			k.ACF_TurretAncestor = nil
 			if Class == "acf_turret" then
@@ -499,6 +627,7 @@ do	-- Spawn and Update funcs
 		end
 
 		Entity.StaticMass = Mass
+		Entity.HasDirectWeapon = HasDirectWeapon
 
 		local Rotator = Entity.Rotator
 		for Ent, PhysObj in pairs(AddCoM) do
@@ -507,6 +636,8 @@ do	-- Spawn and Update funcs
 		end
 
 		Entity.StaticCoM = CoM
+
+		UpdateWeaponized(Entity, HasDirectWeapon)
 	end
 
 	local function GetDynamicMass(Entity) -- Returns mass center (local to rotator) and amount from all "dynamic" entities, should be triggered after a resettable delay (only delayable by so long) in order to reduce spammed calls
@@ -751,6 +882,17 @@ do -- Overlay
 			State:AddKeyValue("Arc", SelfTbl.MinDeg .. "/" .. SelfTbl.MaxDeg)
 		end
 
+		if SelfTbl.IsWeaponized then
+			State:AddKeyValue("Weaponized", "Yes")
+			if SelfTbl.IsControlled then
+				State:AddKeyValue("Controlled", "Yes")
+			else
+				State:AddError("Uncontrolled: aim only updates every " .. ACF.UncontrolledAimUpdateInterval .. "s")
+			end
+		else
+			State:AddKeyValue("Weaponized", "No")
+		end
+
 		if IsValid(SelfTbl.Motor) then
 			State:AddKeyValue("Motor", tostring(SelfTbl.Motor))
 		end
@@ -874,6 +1016,19 @@ do -- Metamethods
 				duplicator.StoreEntityModifier(self, "ACFGyro", {SelfTbl.Gyro:EntIndex()})
 			end
 
+			-- Lightweight Turret Controllers. Stored turret-side, not controller-side, since
+			-- the controller's link has a periodic Check that would otherwise gate the very
+			-- first paste-time relink before contraption/mass data has settled
+			if SelfTbl.LightweightControllers and next(SelfTbl.LightweightControllers) then
+				local Indices = {}
+				for Controller in pairs(SelfTbl.LightweightControllers) do
+					if IsValid(Controller) then Indices[#Indices + 1] = Controller:EntIndex() end
+				end
+				if #Indices > 0 then
+					duplicator.StoreEntityModifier(self, "ACFLightweightControllers", Indices)
+				end
+			end
+
 			-- Wire dupe info
 			self.BaseClass.PreEntityCopy(self)
 		end
@@ -891,6 +1046,15 @@ do -- Metamethods
 				self:Link(CreatedEntities[EntMods.ACFGyro[1]])
 
 				EntMods.ACFGyro = nil
+			end
+
+			if EntMods.ACFLightweightControllers then
+				for _, Index in ipairs(EntMods.ACFLightweightControllers) do
+					local Controller = CreatedEntities[Index]
+					if IsValid(Controller) then Controller:Link(self) end
+				end
+
+				EntMods.ACFLightweightControllers = nil
 			end
 
 			self.BaseClass.PostEntityPaste(self, Player, Ent, CreatedEntities)
@@ -915,10 +1079,7 @@ do -- Metamethods
 		end
 		ENT.SetSoundState = SetSoundState
 
-		function ENT:InputDirection(Direction)
-			local SelfTbl = ENTITY.GetTable(self)
-			if SelfTbl.Disabled then return end
-
+		local function ApplyDirection(SelfTbl, Direction)
 			SelfTbl.Manual		= true
 			SelfTbl.UseVector	= false
 
@@ -930,8 +1091,11 @@ do -- Metamethods
 			SelfTbl.Manual		= false
 
 			if isangle(Direction) then
-				Direction:Normalize()
-				SelfTbl.DesiredAngle = Direction
+				-- Copy before normalizing in place, Direction may still be stored as
+				-- LastRequestedDirection/PendingDirection and must not be mutated
+				local Normalized = Angle(Direction)
+				Normalized:Normalize()
+				SelfTbl.DesiredAngle = Normalized
 
 				return
 			end
@@ -943,8 +1107,42 @@ do -- Metamethods
 			end
 		end
 
+		function ENT:InputDirection(Direction)
+			local SelfTbl = ENTITY.GetTable(self)
+			if SelfTbl.Disabled then return end
+
+			-- Nothing changed since the last request: no-op, don't touch the cooldown at all.
+			-- Wire/E2 typically re-sends the same value every tick, so this keeps a steady
+			-- unchanged input from ever starting/extending a wait
+			if SelfTbl.LastRequestedDirection == Direction then return end
+			SelfTbl.LastRequestedDirection = Direction
+
+			-- A weaponized, uncontrolled turret only accepts a new aim target once every
+			-- ACF.UncontrolledAimUpdateInterval seconds after the input actually changes.
+			-- Stabilization and slewing towards the last accepted target continue every tick
+			-- regardless. A change that arrives mid-cooldown is remembered and applied the
+			-- moment the cooldown lapses, rather than being discarded outright
+			if SelfTbl.IsWeaponized and not SelfTbl.IsControlled and Clock.CurTime < SelfTbl.LastAimInputTime + ACF.UncontrolledAimUpdateInterval then
+				SelfTbl.PendingDirection = Direction
+				return
+			end
+
+			SelfTbl.LastAimInputTime = Clock.CurTime
+			SelfTbl.PendingDirection = nil
+			ApplyDirection(SelfTbl, Direction)
+		end
+
 		function ENT:Think() -- The meat and POE-TAE-TOES of the turret working
 			local SelfTbl = ENTITY.GetTable(self)
+
+			-- A direction that changed mid-cooldown was deferred rather than discarded.
+			-- Apply it as soon as the cooldown lapses, without waiting for another new input
+			if SelfTbl.PendingDirection ~= nil and Clock.CurTime >= SelfTbl.LastAimInputTime + ACF.UncontrolledAimUpdateInterval then
+				SelfTbl.LastAimInputTime = Clock.CurTime
+				local Pending = SelfTbl.PendingDirection
+				SelfTbl.PendingDirection = nil
+				ApplyDirection(SelfTbl, Pending)
+			end
 
 			if SelfTbl.Disabled then
 				SetSoundState(self, false, SelfTbl)

--- a/lua/entities/acf_turret/init.lua
+++ b/lua/entities/acf_turret/init.lua
@@ -543,11 +543,6 @@ do	-- Spawn and Update funcs
 		end
 	end
 
-	local WeaponTypes = {
-		acf_gun		= true,
-		acf_rack	= true
-	}
-
 	--- Refreshes IsWeaponized and bubbles a change one hop up to ACF_TurretAncestor. Never
 	--- recurses into a sub-turret's subtree, only reads its already-cached IsWeaponized.
 	local function UpdateWeaponized(Entity, HasDirectWeapon)
@@ -590,7 +585,7 @@ do	-- Spawn and Update funcs
 		for k in pairs(ChildList) do
 			local Class = k:GetClass()
 
-			if WeaponTypes[Class] then HasDirectWeapon = true end
+			if ACF.WeaponClasses[Class] then HasDirectWeapon = true end
 
 			k.ACF_TurretAncestor = nil
 			if Class == "acf_turret" then

--- a/lua/entities/acf_turret/init.lua
+++ b/lua/entities/acf_turret/init.lua
@@ -31,8 +31,7 @@ local UnlinkSound = "physics/metal/metal_box_impact_bullet%s.wav"
 do -- Random timer crew stuff
 	local LightweightMassLimit = 250 -- kg. Turrets at or under this carried mass can be controlled by a shared-parent Gunner, or a Lightweight Turret Controller, without needing to be mounted on it
 
-	--- Whether a single Gunner-role crew member currently renders this turret controlled,
-	--- and whether that control should cascade to vertical drives mounted on it.
+	--- Whether Crew renders Turret controlled, and whether that cascades to vertical drives.
 	local function CrewGrantsControl(Turret, Crew)
 		if ENTITY.GetTable(Crew).TotalEff < ACF.GunnerEfficiencyThreshold then return false, false end
 
@@ -52,12 +51,8 @@ do -- Random timer crew stuff
 		return false, false
 	end
 
-	--- Renders this turret controlled based on whichever linked Gunner/Commander/Pilot
-	--- currently qualifies, OR-ed with an immediate horizontal ancestor's cascade if this is
-	--- a vertical drive. Each turret only ever sets its own IsControlled, never a sub-turret's,
-	--- to avoid two separate UpdateControlled calls racing to overwrite the same field.
-	--- A Lightweight Turret Controller linked directly to a turret always cascades too, since
-	--- it isn't "riding" the horizontal drive the way a mounted Gunner would be.
+	-- Each turret only ever sets its own IsControlled (never a sub-turret's), to avoid two
+	-- UpdateControlled calls racing to overwrite the same field.
 	local function HasActiveLightweightController(Turret)
 		for Controller in pairs(Turret.LightweightControllers or {}) do
 			if IsValid(Controller) and Controller:IsActive() then return true end
@@ -65,38 +60,37 @@ do -- Random timer crew stuff
 		return false
 	end
 
+	-- Whether any Gunner/Commander/Pilot crew linked to Turret grants control, or a Lightweight
+	-- Controller does. Cascade checks the cascade-to-vertical-drives result instead of self-control
+	local function IsGrantedControl(Turret, Cascade)
+		if HasActiveLightweightController(Turret) then return true end
+
+		local CrewsByType = Turret.CrewsByType
+		if not CrewsByType then return false end
+
+		for _, CrewType in ipairs({"Gunner", "Commander", "Pilot"}) do
+			for Crew in pairs(CrewsByType[CrewType] or {}) do
+				if not IsValid(Crew) then continue end
+
+				local Controls, Cascades = CrewGrantsControl(Turret, Crew)
+				if Cascade and Cascades then return true end
+				if not Cascade and Controls then return true end
+			end
+		end
+
+		return false
+	end
+
 	function ENT:UpdateControlled()
 		local SelfTbl = ENTITY.GetTable(self)
 		SelfTbl.CrewsByType = SelfTbl.CrewsByType or {}
 
-		local Controlled = HasActiveLightweightController(self)
-
-		if not Controlled then
-			for _, CrewType in ipairs({"Gunner", "Commander", "Pilot"}) do
-				for Crew in pairs(SelfTbl.CrewsByType[CrewType] or {}) do
-					if not IsValid(Crew) then continue end
-
-					local CrewControls = CrewGrantsControl(self, Crew)
-					if CrewControls then Controlled = true end
-				end
-			end
-		end
+		local Controlled = IsGrantedControl(self, false)
 
 		if not Controlled and SelfTbl.Turret == "Turret-V" then
 			local Ancestor = SelfTbl.ACF_TurretAncestor
 			if IsValid(Ancestor) and Ancestor.Turret == "Turret-H" then
-				if HasActiveLightweightController(Ancestor) then
-					Controlled = true
-				else
-					for _, CrewType in ipairs({"Gunner", "Commander", "Pilot"}) do
-						for Crew in pairs(Ancestor.CrewsByType and Ancestor.CrewsByType[CrewType] or {}) do
-							if not IsValid(Crew) then continue end
-
-							local _, CrewCascades = CrewGrantsControl(Ancestor, Crew)
-							if CrewCascades then Controlled = true end
-						end
-					end
-				end
+				Controlled = IsGrantedControl(Ancestor, true)
 			end
 		end
 
@@ -216,10 +210,8 @@ do	-- Spawn and Update funcs
 		Entity.DesiredVector = Vector()
 		Entity.DesiredDeg	= 0
 
-		-- Whether a qualifying Gunner/Commander/Pilot (or component) currently controls this
-		-- turret. Only matters while weaponized; an uncontrolled weaponized turret only accepts
-		-- a new aim input once every ACF.UncontrolledAimUpdateInterval seconds after the input
-		-- actually changes, rather than on a fixed clock unrelated to whether anything changed
+		-- Whether a Gunner/Commander/Pilot (or component) controls this turret; only matters
+		-- while weaponized (see InputDirection for what happens when uncontrolled)
 		Entity.IsControlled		= false
 		Entity.LastAimInputTime	= 0
 		Entity.LastRequestedDirection = nil
@@ -506,8 +498,7 @@ do	-- Spawn and Update funcs
 		local OldAncestor = SelfTbl.ACF_TurretAncestor
 		if not IsValid(OldAncestor) then return end
 
-		-- Notify the old ancestor even if it's no longer actually an ancestor (e.g. this
-		-- entity just unparented from it), so it can recompute mass/weaponized without us
+		-- Notify even if no longer actually an ancestor, so it can recompute without us
 		OldAncestor:UpdateTurretMass(false)
 
 		if not Contraption.HasAncestor(self, OldAncestor) then
@@ -535,8 +526,7 @@ do	-- Spawn and Update funcs
 			Entity.ACF_OnMassChange		= Proxy_ACF_OnMassChange
 			Entity.ACF_TurretAncestor	= Turret
 
-			-- Deletion doesn't reparent, so CFW_OnParented never fires for it. Notify the
-			-- ancestor here too, or a deleted weapon/dynamic entity leaves it stuck stale
+			-- Deletion doesn't reparent, so CFW_OnParented never fires for it
 			Entity:CallOnRemove("ACF_TurretAncestorNotify", function()
 				if IsValid(Turret) then Turret:UpdateTurretMass(false) end
 			end)
@@ -558,9 +548,8 @@ do	-- Spawn and Update funcs
 		acf_rack	= true
 	}
 
-	--- Refreshes IsWeaponized from direct children plus each sub-turret's own already-cached
-	--- value, then bubbles a change one hop up to ACF_TurretAncestor. Cheap: never recurses
-	--- into a sub-turret's subtree, only reads the boolean it already computed for itself.
+	--- Refreshes IsWeaponized and bubbles a change one hop up to ACF_TurretAncestor. Never
+	--- recurses into a sub-turret's subtree, only reads its already-cached IsWeaponized.
 	local function UpdateWeaponized(Entity, HasDirectWeapon)
 		local Weaponized = HasDirectWeapon
 
@@ -1016,9 +1005,8 @@ do -- Metamethods
 				duplicator.StoreEntityModifier(self, "ACFGyro", {SelfTbl.Gyro:EntIndex()})
 			end
 
-			-- Lightweight Turret Controllers. Stored turret-side, not controller-side, since
-			-- the controller's link has a periodic Check that would otherwise gate the very
-			-- first paste-time relink before contraption/mass data has settled
+			-- Stored turret-side since the controller's periodic link Check would otherwise
+			-- gate the very first paste-time relink before contraption/mass data has settled
 			if SelfTbl.LightweightControllers and next(SelfTbl.LightweightControllers) then
 				local Indices = {}
 				for Controller in pairs(SelfTbl.LightweightControllers) do
@@ -1091,8 +1079,7 @@ do -- Metamethods
 			SelfTbl.Manual		= false
 
 			if isangle(Direction) then
-				-- Copy before normalizing in place, Direction may still be stored as
-				-- LastRequestedDirection/PendingDirection and must not be mutated
+				-- Copy first, Direction may still be stored elsewhere and must not be mutated
 				local Normalized = Angle(Direction)
 				Normalized:Normalize()
 				SelfTbl.DesiredAngle = Normalized
@@ -1111,17 +1098,12 @@ do -- Metamethods
 			local SelfTbl = ENTITY.GetTable(self)
 			if SelfTbl.Disabled then return end
 
-			-- Nothing changed since the last request: no-op, don't touch the cooldown at all.
-			-- Wire/E2 typically re-sends the same value every tick, so this keeps a steady
-			-- unchanged input from ever starting/extending a wait
+			-- No-op on an unchanged value, so a steady wire input never touches the cooldown
 			if SelfTbl.LastRequestedDirection == Direction then return end
 			SelfTbl.LastRequestedDirection = Direction
 
-			-- A weaponized, uncontrolled turret only accepts a new aim target once every
-			-- ACF.UncontrolledAimUpdateInterval seconds after the input actually changes.
-			-- Stabilization and slewing towards the last accepted target continue every tick
-			-- regardless. A change that arrives mid-cooldown is remembered and applied the
-			-- moment the cooldown lapses, rather than being discarded outright
+			-- Uncontrolled weaponized turrets only accept a changed aim target once every
+			-- ACF.UncontrolledAimUpdateInterval seconds; stabilization/slewing continue as normal
 			if SelfTbl.IsWeaponized and not SelfTbl.IsControlled and Clock.CurTime < SelfTbl.LastAimInputTime + ACF.UncontrolledAimUpdateInterval then
 				SelfTbl.PendingDirection = Direction
 				return
@@ -1135,8 +1117,7 @@ do -- Metamethods
 		function ENT:Think() -- The meat and POE-TAE-TOES of the turret working
 			local SelfTbl = ENTITY.GetTable(self)
 
-			-- A direction that changed mid-cooldown was deferred rather than discarded.
-			-- Apply it as soon as the cooldown lapses, without waiting for another new input
+			-- Apply a deferred mid-cooldown change once the cooldown lapses
 			if SelfTbl.PendingDirection ~= nil and Clock.CurTime >= SelfTbl.LastAimInputTime + ACF.UncontrolledAimUpdateInterval then
 				SelfTbl.LastAimInputTime = Clock.CurTime
 				local Pending = SelfTbl.PendingDirection

--- a/lua/entities/acf_turret/init.lua
+++ b/lua/entities/acf_turret/init.lua
@@ -29,8 +29,6 @@ local MaxLinkDistance = ACF.LinkDistance ^ 2
 local UnlinkSound = "physics/metal/metal_box_impact_bullet%s.wav"
 
 do -- Random timer crew stuff
-	local LightweightMassLimit = 250 -- kg. Turrets at or under this carried mass can be controlled by a shared-parent Gunner, or a Lightweight Turret Controller, without needing to be mounted on it
-
 	--- Whether Crew renders Turret controlled, and whether that cascades to vertical drives.
 	local function CrewGrantsControl(Turret, Crew)
 		if ENTITY.GetTable(Crew).TotalEff < ACF.GunnerEfficiencyThreshold then return false, false end
@@ -44,7 +42,7 @@ do -- Random timer crew stuff
 
 		if CrewParent == Turret:GetParent() then -- Shares a parent with the turret
 			local CarriedMass = (Turret.TurretData.TotalMass or 0) + (Turret.ACF.Mass or 0)
-			if CarriedMass <= LightweightMassLimit then return true, true end
+			if CarriedMass <= ACF.LightweightTurretMassLimit then return true, true end
 			return true, false -- Controls, but no cascade to vertical drives
 		end
 

--- a/lua/entities/acf_turret_controller/cl_init.lua
+++ b/lua/entities/acf_turret_controller/cl_init.lua
@@ -1,0 +1,1 @@
+include("shared.lua")

--- a/lua/entities/acf_turret_controller/init.lua
+++ b/lua/entities/acf_turret_controller/init.lua
@@ -1,0 +1,385 @@
+AddCSLuaFile("cl_init.lua")
+AddCSLuaFile("shared.lua")
+
+include("shared.lua")
+
+-- Local Vars
+
+local ACF			= ACF
+local Contraption	= ACF.Contraption
+local Classes		= ACF.Classes
+local Utilities		= ACF.Utilities
+local HookRun		= hook.Run
+
+do	-- Spawn and Update funcs
+	local WireIO	= Utilities.WireIO
+	local Entities	= Classes.Entities
+	local Turrets	= Classes.Turrets
+
+	local Outputs	= {
+		"Entity (The controller itself.) [ENTITY]"
+	}
+
+	local function VerifyData(Data)
+		if not Data.Controller then Data.Controller = Data.Id end
+
+		local Class = Classes.GetGroup(Turrets, Data.Controller)
+
+		if not Class then
+			Class = Turrets.Get("5-Controller")
+
+			Data.Destiny	= "TurretControllers"
+			Data.Controller	= "Lightweight"
+		end
+
+		local Controller = Turrets.GetItem(Class.ID, Data.Controller)
+
+		if not Controller then
+			Controller = Turrets.GetItem(Class.ID, "Lightweight")
+		end
+
+		Data.ID = Controller.ID
+	end
+
+	------------------
+
+	local function UpdateController(Entity, Data, Class, Controller)
+		Contraption.SetModel(Entity, Controller.Model)
+
+		Entity:PhysicsInit(SOLID_VPHYSICS)
+		Entity:SetMoveType(MOVETYPE_VPHYSICS)
+
+		Entity.Name			= Controller.Name
+		Entity.ShortName	= Controller.ID
+		Entity.EntType		= Class.Name
+		Entity.ClassData	= Class
+		Entity.Class		= Class.ID
+		Entity.Controller	= Data.Controller
+		Entity.IsRemote		= Controller.IsRemote and true or false
+		Entity.Active		= true
+
+		WireIO.SetupOutputs(Entity, Outputs, Data, Class, Controller)
+
+		Entity:SetNWString("WireName", "ACF " .. Entity.Name)
+		Entity:SetNWString("Class", Entity.Class)
+
+		for _, v in ipairs(Entity.DataStore) do
+			Entity[v] = Data[v]
+		end
+
+		ACF.Activate(Entity, true)
+
+		Entity.DamageScale	= math.max((Entity.ACF.Health / (Entity.ACF.MaxHealth * 0.75)) - 0.25 / 0.75, 0)
+
+		Contraption.SetMass(Entity, Controller.Mass)
+	end
+
+	function ACF.MakeTurretController(Player, Pos, Angle, Data)
+		VerifyData(Data)
+
+		local Class = Classes.GetGroup(Turrets, Data.Controller)
+		local Controller = Turrets.GetItem(Class.ID, Data.Controller)
+		local Limit	= Controller.LimitConVar.Name
+
+		if not Player:CheckLimit(Limit) then return end
+
+		local CanSpawn	= HookRun("ACF_PreSpawnEntity", "acf_turret_controller", Player, Data, Class, Controller)
+
+		if CanSpawn == false then return end
+
+		local Entity = ents.Create("acf_turret_controller")
+
+		if not IsValid(Entity) then return end
+
+		Player:AddCleanup(Class.Cleanup, Entity)
+		Player:AddCount(Limit, Entity)
+
+		Entity.ACF				= {}
+
+		Contraption.SetModel(Entity, Controller.Model)
+
+		Entity:SetAngles(Angle)
+		Entity:SetPos(Pos)
+		Entity:Spawn()
+
+		Entity.DataStore		= Entities.GetArguments("acf_turret_controller")
+
+		UpdateController(Entity, Data, Class, Controller)
+
+		HookRun("ACF_OnSpawnEntity", "acf_turret_controller", Entity, Data, Class, Controller)
+
+		return Entity
+	end
+
+	Entities.Register("acf_turret_controller", ACF.MakeTurretController, "Controller")
+
+	function ENT:Update(Data)
+		VerifyData(Data)
+
+		local Class = Classes.GetGroup(Turrets, Data.Controller)
+		local Controller = Turrets.GetItem(Class.ID, Data.Controller)
+		local OldClass	= self.ClassData
+
+		local CanUpdate, Reason = HookRun("ACF_PreUpdateEntity", "acf_turret_controller", self, Data, Class, Controller)
+
+		if CanUpdate == false then return CanUpdate, Reason end
+
+		HookRun("ACF_OnEntityLast", "acf_turret_controller", self, OldClass)
+
+		ACF.SaveEntity(self)
+
+		UpdateController(self, Data, Class, Controller)
+
+		ACF.RestoreEntity(self)
+
+		HookRun("ACF_OnUpdateEntity", "acf_turret_controller", self, Data, Class, Controller)
+
+		return true, "Turret Controller updated successfully!"
+	end
+end
+
+do	-- Metamethods
+	do	-- Overlay stuff
+		function ENT:ACF_UpdateOverlayState(State)
+			if self.IsRemote then
+				State:AddKeyValue("Linked to", IsValid(self.Crew) and tostring(self.Crew) or "Not linked")
+			else
+				State:AddKeyValue("Linked to", IsValid(self.Turret) and tostring(self.Turret) or "Not linked")
+			end
+
+			if self.Active then
+				State:AddKeyValue("Status", "Active")
+			else
+				State:AddError("Inactive: " .. self.InactiveReason)
+			end
+		end
+	end
+
+	do	-- ACF Funcs
+		function ENT:Enable()
+			self:SetActive(true, "")
+			self:UpdateOverlay()
+		end
+
+		function ENT:Disable()
+			self.Active	= false
+			self:SetActive(false, "")
+			self:UpdateOverlay()
+		end
+
+		function ENT:ACF_PostDamage()
+			self.DamageScale = math.max((self.ACF.Health / (self.ACF.MaxHealth * 0.75)) - 0.25 / 0.75, 0)
+		end
+
+		function ENT:ACF_OnRepaired()
+			self.DamageScale = math.max((self.ACF.Health / (self.ACF.MaxHealth * 0.75)) - 0.25 / 0.75, 0)
+		end
+
+		function ENT:SetActive(Active, Reason)
+			local Trigger = (self.Active ~= Active) or (self.InactiveReason ~= Reason)
+			if not Active then
+				self.InactiveReason = Reason
+				self.Active = false
+			else
+				self.InactiveReason = ""
+				self.Active = true
+			end
+
+			if Trigger then self:UpdateOverlay(true) end
+		end
+
+		-- Whether this controller is currently providing its benefit
+		function ENT:IsActive()
+			if self.Disabled then return false end
+
+			local Linked = self.IsRemote and self.Crew or self.Turret
+			if not IsValid(Linked) then self:SetActive(false, "") return false end
+
+			if (self.ACF.Health / self.ACF.MaxHealth) <= 0.25 then
+				self:SetActive(false, "Too damaged!")
+				return false
+			end
+
+			if self.Active == false then self:SetActive(true, "") end
+			return true
+		end
+
+		function ENT:GetCost()
+			return self.IsRemote and 10 or 5
+		end
+	end
+
+	do	-- Dupe support
+		-- Only the Remote variant's crew link is handled here. The Lightweight variant's
+		-- turret link is instead re-established by acf_turret's own dupe support, the same
+		-- way it already handles its motor/gyro links, since acf_turret is the side without
+		-- a periodic Check gate that could reject a paste-time relink before contraption/mass
+		-- data has settled
+		function ENT:PreEntityCopy()
+			if self.IsRemote and IsValid(self.Crew) then
+				duplicator.StoreEntityModifier(self, "ACFCrew", {self.Crew:EntIndex()})
+			end
+
+			-- Wire dupe info
+			self.BaseClass.PreEntityCopy(self)
+		end
+
+		function ENT:PostEntityPaste(Player, Ent, CreatedEntities)
+			local EntMods = Ent.EntityMods
+
+			if EntMods.ACFCrew then
+				self:Link(CreatedEntities[EntMods.ACFCrew[1]])
+
+				EntMods.ACFCrew = nil
+			end
+
+			self.BaseClass.PostEntityPaste(self, Player, Ent, CreatedEntities)
+		end
+	end
+end
+
+do	-- Lightweight Turret Controllers link to acf_turret directly, no crew involved
+	local MaxDistance = 24 * 24 -- Only close-proximity linking is allowed, tighter than standard ACF.LinkDistance
+	local MassLimit = 250 -- Total mass a turret can carry (including itself) to still be controllable by a lightweight controller
+
+	ACF.RegisterLinkSource("acf_turret_controller", "Turret")
+
+	ACF.RegisterClassPreLinkCheck("acf_turret_controller", "acf_turret", function(This)
+		if This.IsRemote then return false, "Remote Turret Controllers link to crew, not turrets. Link the crew member instead." end
+		if IsValid(This.Turret) then return false, "This controller is already linked to a turret." end
+		return true
+	end)
+
+	ACF.RegisterClassLinkCheck("acf_turret_controller", "acf_turret", function(This, Turret)
+		-- ACF.PerformClassLink runs the Check role (this function) before PreLinkCheck, so the
+		-- wrong-variant rejection has to be repeated here too, or a Remote controller linking to
+		-- a turret could fail with a misleading distance/mass error instead of the real reason
+		if This.IsRemote then return false, "Remote Turret Controllers link to crew, not turrets. Link the crew member instead." end
+
+		if This:GetPos():DistToSqr(Turret:GetPos()) > MaxDistance then return false, "This turret is too far from the controller." end
+
+		-- A freshly pasted entity's contraption isn't assigned yet at the moment a paste-time
+		-- relink runs, so only reject on an actual mismatch, not on either side still being nil.
+		-- Matches the same guard acf_crew's periodic contraption check uses for the same reason
+		local ThisContraption = This:CFW_GetContraption()
+		local TurretContraption = Turret:CFW_GetContraption()
+		if ThisContraption ~= nil and TurretContraption ~= nil and ThisContraption ~= TurretContraption then
+			return false, "This controller and turret are not part of the same contraption."
+		end
+
+		local CarriedMass = (Turret.TurretData and Turret.TurretData.TotalMass or 0) + (Turret.ACF and Turret.ACF.Mass or 0)
+		if CarriedMass > MassLimit then return false, "This turret is too heavy for a Lightweight Turret Controller." end
+
+		return true
+	end)
+
+	ACF.RegisterClassLink("acf_turret_controller", "acf_turret", function(This, Turret)
+		This.Turret = Turret
+
+		Turret.LightweightControllers = Turret.LightweightControllers or {}
+		Turret.LightweightControllers[This] = true
+
+		This:UpdateOverlay(true)
+		Turret:UpdateOverlay()
+
+		return true, "Lightweight Turret Controller linked successfully."
+	end)
+
+	ACF.RegisterClassUnlink("acf_turret_controller", "acf_turret", function(This, Turret)
+		if This.Turret ~= Turret then return false, "This controller isn't linked to this turret." end
+
+		This.Turret = nil
+
+		if Turret.LightweightControllers then Turret.LightweightControllers[This] = nil end
+
+		This:UpdateOverlay(true)
+		Turret:UpdateOverlay()
+
+		return true, "Lightweight Turret Controller unlinked successfully."
+	end)
+end
+
+do	-- Remote Turret Controllers link to a Gunner-role crew member
+	local MaxDistance = ACF.LinkDistance ^ 2
+	local MaxViewAngle = 60 -- Degrees off the controller's position can be from the crew while still counting as being "in front" of them
+
+	-- Crew entities are positioned at their model origin (feet, or lower torso depending on
+	-- model), which is a poor reference point for distance/facing/LOS checks against something
+	-- placed near head height. ScanOffsetL is the same per-model body-height offset already used
+	-- elsewhere (oxygen checks, G-force tracking, gun/rack/ammo crew-position checks).
+	local function GetCrewBodyPos(Crew)
+		return Crew:LocalToWorld(Crew.CrewModel.ScanOffsetL)
+	end
+
+	local function HasLineOfSight(This, Crew)
+		local Trace = util.TraceLine({
+			start = This:GetPos(),
+			endpos = GetCrewBodyPos(Crew),
+			filter = {This, Crew},
+			mask = MASK_SOLID_BRUSHONLY
+		})
+
+		return not Trace.Hit
+	end
+
+	-- "In front of the crew member" means the controller sits within the crew's own forward
+	-- view cone, not that the controller prop itself is angled toward the crew. Crew models'
+	-- angles are authored such that their actual forward-facing direction is -GetRight(), not
+	-- GetForward(); GetForward() points out of their side instead
+	local function IsInFront(This, Crew)
+		local ToController = (This:GetPos() - GetCrewBodyPos(Crew)):GetNormalized()
+		local CrewForward = -Crew:GetRight()
+
+		return ToController:Dot(CrewForward) >= math.cos(math.rad(MaxViewAngle))
+	end
+
+	ACF.RegisterLinkSource("acf_turret_controller", "Crew")
+
+	-- Distance/facing/LOS only need checking once, at link time: a shared parent means the
+	-- controller and crew move together afterwards, so their relative position never changes
+	-- on its own. Only the parent relationship itself needs to keep being checked periodically.
+	ACF.RegisterClassPreLinkCheck("acf_turret_controller", "acf_crew", function(This, Crew)
+		if not This.IsRemote then return false, "Lightweight Turret Controllers link to turrets, not crew." end
+		if IsValid(This.Crew) then return false, "This controller is already linked to a crew member." end
+		if Crew.CrewTypeID ~= "Gunner" and Crew.CrewTypeID ~= "Commander" and Crew.CrewTypeID ~= "Pilot" then
+			return false, "This controller can only link to Gunners, Commanders, or Pilots."
+		end
+		if This:GetPos():DistToSqr(GetCrewBodyPos(Crew)) > MaxDistance then return false, "This crew member is too far from the controller." end
+		if This:GetParent() ~= Crew:GetParent() then return false, "This controller must share a parent with the crew member." end
+		if not IsInFront(This, Crew) then return false, "This crew member must be in front of the controller." end
+		if not HasLineOfSight(This, Crew) then return false, "This controller must have line of sight to the crew member." end
+		return true
+	end)
+
+	ACF.RegisterClassLinkCheck("acf_turret_controller", "acf_crew", function(This, Crew)
+		-- ACF.PerformClassLink runs the Check role (this function) before PreLinkCheck, so the
+		-- wrong-variant rejection has to be repeated here too, or a Lightweight controller linking
+		-- to crew could fail with a misleading parent-mismatch error instead of the real reason
+		if not This.IsRemote then return false, "Lightweight Turret Controllers link to turrets, not crew." end
+
+		if This:GetParent() ~= Crew:GetParent() then return false, "This controller must share a parent with the crew member." end
+		return true
+	end)
+
+	ACF.RegisterClassLink("acf_turret_controller", "acf_crew", function(This, Crew)
+		This.Crew = Crew
+		Crew.RemoteController = This
+
+		This:UpdateOverlay(true)
+		Crew:UpdateOverlay()
+
+		return true, "Remote Turret Controller linked successfully."
+	end)
+
+	ACF.RegisterClassUnlink("acf_turret_controller", "acf_crew", function(This, Crew)
+		if This.Crew ~= Crew then return false, "This controller isn't linked to this crew member." end
+
+		This.Crew = nil
+		if Crew.RemoteController == This then Crew.RemoteController = nil end
+
+		This:UpdateOverlay(true)
+		Crew:UpdateOverlay()
+
+		return true, "Remote Turret Controller unlinked successfully."
+	end)
+end

--- a/lua/entities/acf_turret_controller/init.lua
+++ b/lua/entities/acf_turret_controller/init.lua
@@ -240,7 +240,6 @@ end
 
 do	-- Lightweight Turret Controllers link to acf_turret directly, no crew involved
 	local MaxDistance = 24 * 24 -- Only close-proximity linking is allowed, tighter than standard ACF.LinkDistance
-	local MassLimit = 250 -- Total mass a turret can carry (including itself) to still be controllable by a lightweight controller
 
 	ACF.RegisterLinkSource("acf_turret_controller", "Turret")
 
@@ -268,7 +267,7 @@ do	-- Lightweight Turret Controllers link to acf_turret directly, no crew involv
 		end
 
 		local CarriedMass = (Turret.TurretData and Turret.TurretData.TotalMass or 0) + (Turret.ACF and Turret.ACF.Mass or 0)
-		if CarriedMass > MassLimit then return false, "This turret is too heavy for a Lightweight Turret Controller." end
+		if CarriedMass > ACF.LightweightTurretMassLimit then return false, "This turret is too heavy for a Lightweight Turret Controller." end
 
 		return true
 	end)

--- a/lua/entities/acf_turret_controller/shared.lua
+++ b/lua/entities/acf_turret_controller/shared.lua
@@ -1,0 +1,7 @@
+DEFINE_BASECLASS("acf_base_simple")
+
+ENT.PrintName     	= "ACF Turret Controller"
+ENT.WireDebugName 	= "ACF Turret Controller"
+ENT.PluralName    	= "ACF Turret Controllers"
+
+cleanup.Register("acf_turret_controller")

--- a/lua/ponder/storyboards_cl/acf/tankbasics/crew_basics.lua
+++ b/lua/ponder/storyboards_cl/acf/tankbasics/crew_basics.lua
@@ -173,7 +173,7 @@ local Chapter = Storyboard:Chapter("Drivers")
 Chapter:AddDelay(1)
 
 local _, Name = Chapter:AddInstruction("Caption", {
-    Text = "Drivers affect the fuel consumption rate of your engines.\nLink and parent them to your baseplate.\nThey can only be linked to one entity.",
+    Text = "Drivers let your gearboxes apply engine torque at full effect.\nLink and parent them to your baseplate.\nThey can only be linked to one entity.",
     Position = Vector(0.5, 0.15, 0),
     KeepText = true,
 })
@@ -189,7 +189,7 @@ local Chapter = Storyboard:Chapter("Gunners")
 Chapter:AddDelay(1)
 
 local _, Name = Chapter:AddInstruction("Caption", {
-    Text = "Gunners affect the accuracy of your guns.\nLink and parent them to your turret ring/baseplate, whichever the guns are located on.\nThey can only be linked to one entity.",
+    Text = "Gunners let a weaponized turret update its aim freely, instead of only once every few seconds.\nLink and parent them to your turret ring.\nThey can only be linked to one entity.",
     Position = Vector(0.5, 0.15, 0),
     KeepText = true,
 })
@@ -233,7 +233,7 @@ Chapter:AddInstruction("HideText", {Name = Name}):DelayByLength()
 Chapter:AddDelay(1)
 
 local _, Name = Chapter:AddInstruction("Caption", {
-    Text = "They can be linked to guns and turret rings as you would with a loader and gunner.\nThis is for RWSes and the like, but it impacts their ability to command.",
+    Text = "They can be linked to guns and turret rings to fill in as a Loader or Gunner.\nThis is for RWSes and the like, but it impacts their ability to command.",
     Position = Vector(0.5, 0.15, 0),
     KeepText = true,
 })

--- a/resource/localization/en/acf_entity_cleanup.properties
+++ b/resource/localization/en/acf_entity_cleanup.properties
@@ -1,22 +1,22 @@
 # acf_ammo
 Cleanup_acf_ammo=ACF Ammo Crates
 Cleaned_acf_ammo=Cleaned up all ACF Ammo Crates
-SBoxLimit__acf_ammo=You've reached the ACF Ammo Crates limit!
+SBoxLimit__acf_ammo=You've reached the ACF Ammo Crate limit!
 
 # acf_autoloader
 Cleanup_acf_autoloader=ACF Autoloaders
 Cleaned_acf_autoloader=Cleaned up all ACF autoloaders!
-SBoxLimit__acf_autoloader=You've reached the ACF autoloaders limit!
+SBoxLimit__acf_autoloader=You've reached the ACF autoloader limit!
 
 # acf_baseplate
 Cleanup_acf_baseplate=ACF Baseplates
 Cleaned_acf_baseplate=Cleaned up all ACF baseplates!
-SBoxLimit__acf_baseplate=You've reached the ACF baseplates limit!
+SBoxLimit__acf_baseplate=You've reached the ACF baseplate limit!
 
 # acf_controller
 Cleanup_acf_controller=ACF Controllers
 Cleaned_acf_controller=Cleaned up all ACF controllers!
-SBoxLimit__acf_controller=You've reached the ACF controllers limit!
+SBoxLimit__acf_controller=You've reached the ACF controller limit!
 
 # acf_crew
 Cleanup_acf_crew=ACF Crewmates
@@ -32,17 +32,17 @@ SBoxLimit__acf_crew_pilot=You've reached the ACF Pilot limit!
 # acf_engine
 Cleanup_acf_engine=ACF Engines
 Cleaned_acf_engine=Cleaned up all ACF Engines
-SBoxLimit__acf_engine=You've reached the ACF Engines limit!
+SBoxLimit__acf_engine=You've reached the ACF Engine limit!
 
 # acf_fueltank
 Cleanup_acf_fueltank=ACF Fuel Tanks
 Cleaned_acf_fueltank=Cleaned up all ACF Fuel Tanks
-SBoxLimit__acf_fueltank=You've reached the ACF Fuel Tanks limit!
+SBoxLimit__acf_fueltank=You've reached the ACF Fuel Tank limit!
 
 # acf_gearbox
 Cleanup_acf_gearbox=ACF Gearboxes
 Cleaned_acf_gearbox=Cleaned up all ACF Gearboxes
-SBoxLimit__acf_gearbox=You've reached the ACF Gearboxes limit!
+SBoxLimit__acf_gearbox=You've reached the ACF Gearbox limit!
 
 # acf_gun
 Cleanup_acf_gun=ACF Weapons
@@ -59,17 +59,23 @@ Cleaned_acf_piledriver=Cleaned up all ACF Piledrivers
 # acf_supply
 Cleanup_acf_supply=ACF Supply Crates
 Cleaned_acf_supply=Cleaned up all ACF supply crates!
-SBoxLimit__acf_supply=You've reached the ACF supply crates limit!
+SBoxLimit__acf_supply=You've reached the ACF supply crate limit!
 
 # acf_turret
 Cleanup_acf_turret=ACF Turrets
 Cleaned_acf_turret=Cleaned up all ACF turrets!
-SBoxLimit__acf_turret=You've reached the ACF turrets limit!
+SBoxLimit__acf_turret=You've reached the ACF turret limit!
 
 # acf_turret_computer
 Cleanup_acf_turret_computer=ACF Ballistic Computers
 Cleaned_acf_turret_computer=Cleaned up all ACF ballistic computers!
-SBoxLimit__acf_turret_computer=You've reached the ACF ballistic computers limit!
+SBoxLimit__acf_turret_computer=You've reached the ACF ballistic computer limit!
+
+# acf_turret_controller
+Cleanup_acf_turret_controller=ACF Turret Controllers
+Cleaned_acf_turret_controller=Cleaned up all ACF turret controllers!
+SBoxLimit__acf_turret_controller_remote=You've reached the ACF remote turret controller limit!
+SBoxLimit__acf_turret_controller_lightweight=You've reached the ACF lightweight turret controller limit!
 
 # acf_turret_gyro
 Cleanup_acf_turret_gyro=ACF Turret Gyroscopes
@@ -79,12 +85,12 @@ SBoxLimit__acf_turret_gyro=You've reached the ACF turret gyroscope limit!
 # acf_turret_motor
 Cleanup_acf_turret_motor=ACF Turret Motors
 Cleaned_acf_turret_motor=Cleaned up all ACF turret motors!
-SBoxLimit__acf_turret_motor=You've reached the ACF turret motors limit!
+SBoxLimit__acf_turret_motor=You've reached the ACF turret motor limit!
 
 # acf_waterjet
 Cleanup_acf_waterjet=ACF Waterjets
 Cleaned_acf_waterjet=Cleaned up all ACF waterjets!
-SBoxLimit__acf_waterjet=You've reached the ACF waterjets limit!
+SBoxLimit__acf_waterjet=You've reached the ACF waterjet limit!
 
 # ACF missile limits.
 # TODO: Move into ACF missiles!

--- a/resource/localization/en/acf_menu_crew.properties
+++ b/resource/localization/en/acf_menu_crew.properties
@@ -21,7 +21,7 @@ acf.menu.crew.efficiency.desc6=The exact efficiencies affecting each crew type o
 # Efficiency Types category
 acf.menu.crew.types=Efficiency Types
 acf.menu.crew.types.desc1=Model efficiency is based on the posture of the crew model for a given occupation. You can find the multiplier below.
-acf.menu.crew.types.desc2=Movement efficiency is based on the G forces the crew experiences. Avoid accelerating too fast or crashing into things.
+acf.menu.crew.types.desc2=Movement efficiency is based on the G-forces the crew experiences. Avoid accelerating too fast or crashing into things.
 acf.menu.crew.types.desc3=Lean angle efficiency is based on the angle of the crew relative to the world. Try to keep them upright.
 acf.menu.crew.types.desc4=Health efficiency is based on how damaged your crew are. Try to protect them from harm.
 acf.menu.crew.types.desc5=Space efficiency only applies to loaders and is based on the amount of surrounding open space they have. Try to give them the most room.

--- a/resource/localization/en/acf_menu_settings.properties
+++ b/resource/localization/en/acf_menu_settings.properties
@@ -38,6 +38,7 @@ acf.menu.settings.effects_visual_elements.particle_mult_desc=Defines the clients
 
 acf.menu.settings.effects_visual_elements.ammo_refill=Ammo Refill Color
 acf.menu.settings.effects_visual_elements.fuel_refill=Fuel Refill Color
+acf.menu.settings.effects_visual_elements.crew_revive=Crew Revive Color
 
 # Legal Checks category
 acf.menu.settings.legal_checks=Legal Checks

--- a/resource/localization/en/acf_menu_turrets.properties
+++ b/resource/localization/en/acf_menu_turrets.properties
@@ -1,7 +1,7 @@
 # General settings labels
 acf.menu.turrets=Turrets
 acf.menu.turrets.menu_title=Procedural Turrets
-acf.menu.turrets.menu_desc=Typically, place the horizontal turret, and then parent a vertical turret to it to make a fully functional turret. You can parent anything directly to the turret pieces and they will be attached and rotate correctly.
+acf.menu.turrets.menu_desc=Typically, place the horizontal turret, and then parent a vertical turret to it to make a fully functional turret. You can parent anything directly to the turret pieces and they will be attached and rotate correctly.\n\nTurrets which have a weapon somewhere along their hierarchy will be considered weaponized, and will be need to be controlled by a Gunner or Turret Controller to avoid a severe aim update rate penalty.
 acf.menu.turrets.components=Turret Components
 acf.menu.turrets.turret_mass_text=Drive Mass : %s kg, %s kg max capacity
 acf.menu.turrets.mass_text=Mass : %s kg
@@ -79,3 +79,10 @@ acf.names.computers.direct=Direct Ballistics Computer
 acf.descs.computers.direct=A component that is capable of calculating the angle required to shoot a weapon to hit a spot within view.\nAs long as Calculate is true, this will continue to track in a straight line from the initial position and velocity.\nHas a 0.2s delay between uses.
 acf.names.computers.indirect=Indirect Ballistics Computer
 acf.descs.computers.indirect=A component that is capable of calculating the angle required to shoot a weapon to hit a spot out of view.\nHas a 1s delay between uses.
+
+acf.names.controllers=Turret Controllers
+acf.descs.controllers=Components that render a weaponized turret "controlled", letting them update their aim freely instead of only once every few seconds.
+acf.names.controllers.remote=Remote Turret Controller
+acf.descs.controllers.remote=Allows a Gunner (or crew performing Gunner duty) to control a weaponized turret it isn't mounted on.\n\nLinks to the crew member, while the crew member links to the turret. Must share a parent with the crew member, be in front of them, and have line of sight to them to link properly.
+acf.names.controllers.lightweight=Lightweight Turret Controller
+acf.descs.controllers.lightweight=Controls a weaponized turret without any crew, as long as everything that turret carries (itself included) weighs 250kg or less.\n\nLinks to the turret. Must remain within 24 units of the turret to link properly.


### PR DESCRIPTION
Still working on a few things before this PR is ready but I figured it's good enough for an initial review.

Reworks Driver/Gunner crew duties, adds turret controllers and crew health mechanics

Drivers now affect gearbox torque
- Removes the old Driver engine fuel consumption implementation
- Drivers (or crew performing Driver duty) gate whether gearboxes of a contraption apply full torque to what they drive with a binary crew efficiency threshold of 30%
- Recreational baseplates are exempt from this, as they were before with the engine fuel consumption implementation

Gunners now control weaponized turrets
- Removes old Gunner weapon accuracy implementation
- New "weaponized" state: any turret with a gun/rack anywhere in its descendant chain
- New "controlled" state: an uncontrolled weaponized turret only accepts a new aim input once every 5s
- Gunners (or crew performing Gunner duty) grant control over weaponized turrets by linking and being parented directly to a turret, sharing a parent with a <= 250kg turret, or via a Remote Turret Controller; Gunner benefit will propagate from Horizontal turrets to parented Vertical turrets when the Gunner is directly parented, is using a Remote Turret Controller, or shares a parent with a turret with a cumulative mass of <= 250kg. Same binary crew efficiency threshold of 30% as Drivers
- Gunners no longer link to acf_baseplate, link them to turrets

New turret controller (acf_turret_controller) entity, with remote and lightweight variants
- Remote Turret Controller: links to a Gunner-role crew member (requires a shared parent, line of sight, and to be in front of them), letting that crew member fully control a weaponized turret it's linked to without being parented to or sharing a parent with it
- Lightweight Turret Controller: links directly to a weaponized turret (24 unit link distance, turret cumulative mass is <= 250kg), providing full control (with propagation to Vertical turrets when linked to a Horizontal turret) over that turret with no Gunner necessary

Crew fixes and additions
- Fixes a Pilot double-link exploit (could be linked to turret + baseplate simultaneously)
- Improves crew replacement to consider all live crew and pick the least important one
- Adjusts G-force efficiency curves; Commander's tolerance curve now branches when it's performing Loader duty
- Removes Pilot's ability to perform Loader duty
- Crew now passively regenerates 5% max health every 10s if alive and contraption is not in combat
- Supply crates can now revive dead crew

Misc
- Fixes link check error order so errors better convey what's preventing a link
- Vertical turret elevation limits changed from +-85 to +-90 degrees
- Updates menu text for new mechanics